### PR TITLE
feature: instrumentation to dump pc trace to DRAM

### DIFF
--- a/regression/CMakeLists.txt
+++ b/regression/CMakeLists.txt
@@ -16,7 +16,16 @@ add_executable(
   src/client/tests/asm/asm_helpers.c
   src/client/tests/load-store.cc
   src/client/tests/back-pressure.cc
+  src/client/tests/trace-module.cc
   src/client/tests/host-control.cc
+)
+
+add_executable(
+  StressTest
+  src/client/runs/stress-tests.c
+  src/client/tests/asm/asm_helpers.c
+  src/client/fpga_interface.c
+  src/client/fpga_helpers.c
 )
 
 if(AWS_FPGA_LIBRARY_PATH)
@@ -26,13 +35,21 @@ if(AWS_FPGA_LIBRARY_PATH)
   target_compile_definitions(KnockoutTestGenerator PUBLIC AWS_FPGA)
   target_sources(KnockoutTestGenerator PRIVATE src/client/fpga_aws.c)
   target_link_libraries(KnockoutTestGenerator Threads::Threads fpga_mgmt)
+  
+  target_include_directories(StressTest PUBLIC ${AWS_FPGA_LIBRARY_PATH}/include)
+  target_link_directories(StressTest PUBLIC ${AWS_FPGA_LIBRARY_PATH}/lib)
+  target_compile_definitions(StressTest PUBLIC AWS_FPGA)
+  target_sources(StressTest PRIVATE src/client/fpga_aws.c)
+  target_link_libraries(StressTest Threads::Threads fpga_mgmt)
+
 else()
   find_package(verilator REQUIRED)
   target_sources(KnockoutTestGenerator PRIVATE src/client/fpga_rtl.c)
   add_executable(KnockoutSimulator src/server/main.cc src/server/dut.cc src/server/subroutine.cc src/server/ipc.cc)
   #set(VERILATOR_ARGS +define+STOP_COND=1'h0)
-  verilate(KnockoutSimulator SOURCES rtl/ARMFlexTop.v rtl/BRAMTDP.v TOP_MODULE ARMFlexTopSimulator TRACE_FST VERILATOR_ARGS)
+  verilate(KnockoutSimulator SOURCES rtl/ARMFlexTop.v rtl/BRAMTDP.v TOP_MODULE ARMFlexTopInstrumented TRACE_FST VERILATOR_ARGS)
   target_link_libraries(KnockoutSimulator PRIVATE Threads::Threads)
+  target_sources(StressTest PRIVATE src/client/fpga_rtl.c src/client/ipc.c)
 endif()
 
 #add_executable(garbage_server src/garbage_server.cc)

--- a/regression/src/client/fpga.h
+++ b/regression/src/client/fpga.h
@@ -9,7 +9,7 @@ typedef struct AXIBaseAddress {
   uint32_t tt;
   uint32_t transplant_data;
   uint32_t transplant_ctl;
-  uint32_t transplant_stopCPU;
+  uint32_t instrumentation_trace;
   uint32_t message_queue; 
 
   uint64_t dram_base;

--- a/regression/src/client/fpga_aws.c
+++ b/regression/src/client/fpga_aws.c
@@ -79,6 +79,7 @@ int initFPGAContext(FPGAContext *c) {
   c->base_address.tt = 0x8000;
   c->base_address.transplant_ctl = 0x9000;
   c->base_address.message_queue = 0x10000;
+  c->base_address.instrumentation_trace = 0x1F000;
 
   c->base_address.dram_base = 0ULL;
   c->base_address.pt_base = 0;

--- a/regression/src/client/fpga_interface.c
+++ b/regression/src/client/fpga_interface.c
@@ -275,3 +275,44 @@ int writeSimCtrl(const FPGAContext *c, int type, int value) {
   return writeAXILMagic(c, type, value);
 }
 #endif
+
+// Instrumentation helpers
+int trace_PC_set_paddr(const FPGAContext *c, uint32_t paddr) {
+  const uint32_t axil_trace_base = c->base_address.axil_base + c->base_address.instrumentation_trace;
+  return writeAXIL(c, axil_trace_base + TRACE_PC_OFFST_PADDR, paddr);
+}
+
+int trace_PC_start(const FPGAContext *c) {
+  const uint32_t axil_trace_base = c->base_address.axil_base + c->base_address.instrumentation_trace;
+  return writeAXIL(c, axil_trace_base + TRACE_PC_OFFST_START, 1 << 0);
+}
+
+int trace_PC_counter_reset(const FPGAContext *c) {
+  const uint32_t axil_trace_base = c->base_address.axil_base + c->base_address.instrumentation_trace;
+  return writeAXIL(c, axil_trace_base + TRACE_PC_OFFST_START, 1 << 1);
+}
+
+int trace_PC_counter_execute(const FPGAContext *c, uint32_t* count) {
+  const uint32_t axil_trace_base = c->base_address.axil_base + c->base_address.instrumentation_trace;
+  return readAXIL(c, axil_trace_base + TRACE_PC_OFFST_CNT_EXE, count);
+}
+
+int trace_PC_counter_stalls(const FPGAContext *c, uint32_t* count) {
+  const uint32_t axil_trace_base = c->base_address.axil_base + c->base_address.instrumentation_trace;
+  return readAXIL(c, axil_trace_base + TRACE_PC_OFFST_CNT_STALLS, count);
+}
+
+int trace_PC_counter_start(const FPGAContext *c) {
+  const uint32_t axil_trace_base = c->base_address.axil_base + c->base_address.instrumentation_trace;
+  return writeAXIL(c, axil_trace_base + TRACE_PC_OFFST_CNT_CTLREG, 1);
+}
+
+int trace_PC_counter_stop(const FPGAContext *c) {
+  const uint32_t axil_trace_base = c->base_address.axil_base + c->base_address.instrumentation_trace;
+  return writeAXIL(c, axil_trace_base + TRACE_PC_OFFST_CNT_CTLREG, 0);
+}
+
+int trace_PC_counter_bursts(const FPGAContext *c, uint32_t* count) {
+  const uint32_t axil_trace_base = c->base_address.axil_base + c->base_address.instrumentation_trace;
+  return readAXIL(c, axil_trace_base + TRACE_PC_OFFST_CNT_BURSTS, count);
+}

--- a/regression/src/client/fpga_interface.h
+++ b/regression/src/client/fpga_interface.h
@@ -194,6 +194,24 @@ static inline void makeMissReply(int type, int thid, int asid, uint64_t va, uint
     miss_reply->MissReply.ppn = GET_PPN_FROM_PADDR(paddr);
 }
 
+// Instrumentation control
+#define TRACE_PC_OFFST_PADDR       (0*0x4)
+#define TRACE_PC_OFFST_START       (1*0x4)
+#define TRACE_PC_OFFST_CNT_EXE     (2*0x4)
+#define TRACE_PC_OFFST_CNT_STALLS  (3*0x4)
+#define TRACE_PC_OFFST_CNT_CTLREG  (4*0x4)
+#define TRACE_PC_OFFST_CNT_BURSTS  (5*0x4)
+
+int trace_PC_set_paddr(const FPGAContext *c, uint32_t paddr);
+int trace_PC_start(const FPGAContext *c);
+int trace_PC_counter_reset(const FPGAContext *c);
+int trace_PC_counter_execute(const FPGAContext *c, uint32_t* count);
+int trace_PC_counter_stalls(const FPGAContext *c, uint32_t* count);
+int trace_PC_counter_bursts(const FPGAContext *c, uint32_t* count);
+int trace_PC_counter_start(const FPGAContext *c);
+int trace_PC_counter_stop(const FPGAContext *c);
+
+
 #ifndef AWS_FPGA
 int writeSimCtrl(const FPGAContext *c, int type, int value);
 #endif

--- a/regression/src/client/fpga_rtl.c
+++ b/regression/src/client/fpga_rtl.c
@@ -28,6 +28,7 @@ int initFPGAContext(FPGAContext *c){
   c->base_address.tt = 0x8000;
   c->base_address.transplant_ctl = 0x9000;
   c->base_address.message_queue = 0x10000;
+  c->base_address.instrumentation_trace = 0x1F000;
 
   c->base_address.dram_base = 0;
   c->base_address.pt_base = 0;

--- a/regression/src/client/runs/stress-tests.c
+++ b/regression/src/client/runs/stress-tests.c
@@ -1,0 +1,82 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+
+#include "../fpga.h"
+#include "../fpga_interface.h"
+#include "../tests/asm/asm_helpers.h"
+#include "../fpga_helpers.h"
+
+int main(int argc, char **argv) {
+    assert(argc != 1);
+    int threads = atoi(argv[1]);
+    printf("Starting with %i threads\n", threads);
+    FPGAContext ctx;
+    ArmflexArchState state;
+    uint8_t page[PAGE_SIZE] = {0};
+    int ret = initFPGAContext(&ctx);
+    printf("initFPGAContext retuned %i, should be 0\n", ret);
+    int paddr = ctx.base_address.page_base;
+
+    printf("Get program page\n");
+    FILE *f = fopen("../src/client/tests/asm/executables/infinite-loop.bin", "rb");
+    assert(f != NULL);
+    assert(fread(page, 1, 4096, f) != 0);
+    fclose(f);
+
+    printf("Push instruction page and state\n");
+    pushPageToFPGA(&ctx, paddr, page);
+    for(int thread = 0; thread < threads; thread++) {
+        initArchState(&state, thread << 12);
+        initState_infinite_loop(&state, true);
+        registerAndPushState(&ctx, thread, thread, &state);
+        MessageFPGA pf_reply;
+        makeMissReply(INST_FETCH, -1, thread, state.pc, paddr, &pf_reply);
+        sendMessageToFPGA(&ctx, &pf_reply, sizeof(pf_reply));
+    }
+
+    printf("Advance\n");
+    advanceTicks(&ctx, 100);
+
+    printf("Start Execution\n");
+    for(int thread = 0; thread < threads; thread++) {
+        transplant_start(&ctx, thread);
+    }
+
+    printf("Advance\n");
+    advanceTicks(&ctx, 100);
+
+    printf("Send start tracing, start and reset counters\n");
+    trace_PC_set_paddr(&ctx, 0x10000);
+    trace_PC_start(&ctx);
+    trace_PC_counter_start(&ctx);
+    trace_PC_counter_reset(&ctx);
+
+    printf("Advance and stop\n");
+    advanceTicks(&ctx, 30000);
+    trace_PC_counter_stop(&ctx);
+
+
+    printf("Get counters\n");
+    uint32_t cntExecute;
+    uint32_t cntStalls;
+    uint32_t cntBursts;
+    trace_PC_counter_execute(&ctx, &cntExecute);
+    trace_PC_counter_stalls(&ctx, &cntStalls);
+    trace_PC_counter_bursts(&ctx, &cntBursts);
+
+    printf("Stop CPU\n");
+    transplant_stopCPU(&ctx, 0);
+
+    printf("Advance\n");
+    advanceTicks(&ctx, 100);
+
+    printf("Print results\n");
+    printf("Executing:%010d\n"
+           "Stalls:   %010d\n"
+           "Bursts:   %010d\n", 
+           cntExecute, cntStalls, cntBursts);
+ 
+    releaseFPGAContext(&ctx);
+}

--- a/regression/src/client/tests/trace-module.cc
+++ b/regression/src/client/tests/trace-module.cc
@@ -1,0 +1,70 @@
+extern "C" {
+#include "../fpga.h"
+#include "../fpga_interface.h"
+#include "asm/asm_helpers.h"
+}
+
+#include "../test-helpers.hh"
+
+TEST_CASE("trace-pcs-then-stop-single") {
+    FPGAContext ctx;
+    ArmflexArchState state;
+    uint8_t page[PAGE_SIZE] = {0};
+    REQUIRE(initFPGAContext(&ctx) == 0);
+    initArchState(&state, 0);
+    initState_infinite_loop(&state, true);
+    int paddr = ctx.base_address.page_base;
+
+    INFO("Get program page");
+    FILE *f = fopen("../src/client/tests/asm/executables/infinite-loop.bin", "rb");
+    REQUIRE(f != nullptr);
+    REQUIRE(fread(page, 1, 4096, f) != 0);
+    fclose(f);
+
+    INFO("Push instruction page and state");
+    pushPageToFPGA(&ctx, paddr, page);
+    int thread = 0;
+    MessageFPGA pf_reply;
+    makeMissReply(INST_FETCH, -1, thread, state.pc, paddr, &pf_reply);
+    sendMessageToFPGA(&ctx, &pf_reply, sizeof(pf_reply));
+    registerAndPushState(&ctx, thread, thread, &state);
+
+    INFO("Advance");
+    advanceTicks(&ctx, 100);
+
+    INFO("Start Execution");
+    transplant_start(&ctx, thread);
+
+    INFO("Advance");
+    advanceTicks(&ctx, 100);
+
+    INFO("Send start tracing, start and reset counters");
+    trace_PC_set_paddr(&ctx, 0x10000);
+    trace_PC_start(&ctx);
+    trace_PC_counter_start(&ctx);
+    trace_PC_counter_reset(&ctx);
+
+    INFO("Advance and stop");
+    advanceTicks(&ctx, 30000);
+    trace_PC_counter_stop(&ctx);
+
+
+    INFO("Get counters");
+    uint32_t cntExecute;
+    uint32_t cntStalls;
+    trace_PC_counter_execute(&ctx, &cntExecute);
+    trace_PC_counter_stalls(&ctx, &cntStalls);
+
+    INFO("Stop CPU");
+    transplant_stopCPU(&ctx, 0);
+
+    INFO("Advance");
+    advanceTicks(&ctx, 100);
+
+    INFO("Print results");
+    printf("Executing:%016d\n"
+           "Stalls:   %016d\n", 
+           cntExecute, cntStalls);
+ 
+    releaseFPGAContext(&ctx);
+}

--- a/regression/src/server/dut.cc
+++ b/regression/src/server/dut.cc
@@ -5,12 +5,15 @@
 
 double TopDUT::time = 0;
 
-TopDUT::TopDUT(size_t dram_size) {
+TopDUT::TopDUT(bool withTrace) {
+  size_t dram_size = 1024 * 1024 * 16;
   dut = new VARMFlexTop();
   dram = new uint32_t[dram_size / 4];
   tfp = new VerilatedFstC;
-  dut->trace(tfp, 99);
-  tfp->open("test.fst");
+  if(withTrace) {
+    dut->trace(tfp, 99);
+    tfp->open("test.fst");
+  }
   ready_thread = 0;
   terminating = false;
   error_occurred = false;
@@ -26,10 +29,12 @@ TopDUT::TopDUT(size_t dram_size) {
 }
 
 TopDUT::~TopDUT() {
-  tfp->close();
+  if (withTrace) {
+    tfp->close();
+    delete tfp;
+  }
   dut->final();
   delete dut;
-  delete tfp;
   delete[] dram;
 }
 

--- a/regression/src/server/dut.hh
+++ b/regression/src/server/dut.hh
@@ -30,7 +30,7 @@
 
 class TopDUT {
 public:
-  TopDUT(size_t dram_size = 1024 * 1024 * 16);
+  TopDUT(bool withTrace = true);
   ~TopDUT();
 
   /**
@@ -148,6 +148,7 @@ private:
   size_t decoupled_count;
   std::vector<std::thread> subroutines;
   bool terminating;
+  bool withTrace;
 
   bool error_occurred;
 

--- a/regression/src/server/main.cc
+++ b/regression/src/server/main.cc
@@ -25,12 +25,15 @@ void signalHandler(int signum) {
 }
 
 int main(int argc, char **argv) {
-  Verilated::commandArgs(argc, argv);
+  bool hasTraceGenerated = true;
+  if(argc > 1) {
+    hasTraceGenerated = false;
+  }
+  //Verilated::commandArgs(argc, argv);
   Verilated::assertOn(false);
-  Verilated::traceEverOn(true);
+  Verilated::traceEverOn(hasTraceGenerated);
 
-
-  TopDUT dut;
+  TopDUT dut (hasTraceGenerated);
 
   signal(SIGINT, signalHandler);
 

--- a/src/main/scala/ARMFlexTop.scala
+++ b/src/main/scala/ARMFlexTop.scala
@@ -2,7 +2,7 @@ import antmicro.Bus.{AXI4, AXI4AR, AXI4AW, AXI4B, AXI4R, AXI4W}
 import chisel3._
 import chisel3.util._
 import armflex._
-import armflex.util.AXILInterconnector
+import armflex.util._
 import armflex_cache._
 import armflex_mmu.{MMU, MemoryHierarchyParams}
 import armflex.util.ExtraUtils._
@@ -77,7 +77,7 @@ class ARMFlexTop(
   assert(paramsPipeline.pAddrW == paramsMemoryHierarchy.pAddrW)
   assert(paramsPipeline.blockSize == paramsMemoryHierarchy.cacheBlockSize)
 
-  private val u_pipeline = Module(new PipelineAxi(paramsPipeline))
+  val u_pipeline = Module(new PipelineAxi(paramsPipeline))
   private val memory = Module(new MemorySystem(paramsMemoryHierarchy))
   u_pipeline.mmu_io <> memory.pipeline_io.mmu
   // TLB interconnect
@@ -103,6 +103,10 @@ class ARMFlexTop(
   val AXI_MEM = IO(memory.axiShell_io.cloneType)
   S_AXIL_TRANSPLANT <> u_pipeline.S_AXIL
   AXI_MEM <> memory.axiShell_io
+
+  // Instrumentation Interface
+  val instrument = IO(u_pipeline.instrument.cloneType)
+  instrument <> u_pipeline.instrument
 }
 
 class ARMFlexTopSimulator(
@@ -114,7 +118,7 @@ class ARMFlexTopSimulator(
   private val devteroFlexTop = Module(new ARMFlexTop(paramsPipeline, paramsMemoryHierarchy))
   private val axiMulti_R = Module(new AXIReadMultiplexer(paramsMemoryHierarchy.dramAddrW, 512, 6))
   private val axiMulti_W = Module(new AXIWriteMultiplexer(paramsMemoryHierarchy.dramAddrW, 512, 5))
-  private val axilMulti = Module(new AXILInterconnector(Seq(0x00000, 0x10000), Seq(0x08000,0x10000), 32, 32))
+  private val axilMulti = Module(new AXILInterconnectorNonOptimized(Seq(0x00000, 0x10000, 0x1F000), 32, 32))
   val S_AXI = IO(Flipped(devteroFlexTop.AXI_MEM.AXI_MMU.S_AXI.cloneType))
   val S_AXIL = IO(Flipped(axilMulti.S_AXIL.cloneType))
   S_AXI <> devteroFlexTop.AXI_MEM.AXI_MMU.S_AXI
@@ -147,6 +151,9 @@ class ARMFlexTopSimulator(
   // Disable Read ports
   axiMulti_W.M_AXI.ar <> AXI4AR.stub(paramsMemoryHierarchy.dramAddrW)
   axiMulti_W.M_AXI.r <> AXI4R.stub(paramsMemoryHierarchy.cacheBlockSize)
+
+  // No Instrumentation enabled in this build, make sure it has no impact downstream
+  devteroFlexTop.instrument.commit.ready := true.B
 }
 
 object ARMFlexTopSimulatorVerilogEmitter extends App {

--- a/src/main/scala/ARMFlexTopInstrumented.scala
+++ b/src/main/scala/ARMFlexTopInstrumented.scala
@@ -1,0 +1,128 @@
+import antmicro.Bus.{AXI4, AXI4AR, AXI4AW, AXI4B, AXI4R, AXI4W}
+import antmicro.CSR._
+import chisel3._
+import chisel3.util._
+import armflex._
+import armflex.util.{ AXILInterconnector, AXIWriteMasterIF}
+import armflex_cache._
+import armflex_mmu.{MMU, MemoryHierarchyParams}
+import armflex.util.ExtraUtils._
+import firrtl.options.TargetDirAnnotation
+import armflex.util.{ DRAMWrapperWrite, DRAMPortParams }
+import instrumentation.{ TraceDump, TraceDumpParams }
+import antmicro.Bus.AXI4Lite
+import armflex.util.PerfCounter
+import armflex.util.AXILInterconnectorNonOptimized
+
+class ARMFlexTopInstrumented(
+  paramsPipeline: PipelineParams,
+  paramsMemoryHierarchy: MemoryHierarchyParams
+) extends MultiIOModule {
+  import armflex.util.AXIReadMultiplexer
+  import armflex.util.AXIWriteMultiplexer
+  private val devteroFlexTop = Module(new ARMFlexTop(paramsPipeline, paramsMemoryHierarchy))
+  private val axiMulti_R = Module(new AXIReadMultiplexer(paramsMemoryHierarchy.dramAddrW, 512, 6))
+  private val axiMulti_W = Module(new AXIWriteMultiplexer(paramsMemoryHierarchy.dramAddrW, 512, 6))
+  //private val axilMulti = Module(new AXILInterconnector(Seq(0x00000, 0x10000, 0x1F000), Seq(0x08000, 0x10000, 0x1F000), 32, 32))
+  private val axilMulti = Module(new AXILInterconnectorNonOptimized(Seq(0x00000, 0x10000, 0x1F000), 32, 32))
+  val S_AXI = IO(Flipped(devteroFlexTop.AXI_MEM.AXI_MMU.S_AXI.cloneType))
+  val S_AXIL = IO(Flipped(axilMulti.S_AXIL.cloneType))
+  S_AXI <> devteroFlexTop.AXI_MEM.AXI_MMU.S_AXI
+  S_AXIL <> axilMulti.S_AXIL
+  axilMulti.M_AXIL(0) <> devteroFlexTop.S_AXIL_TRANSPLANT
+  axilMulti.M_AXIL(1) <> devteroFlexTop.AXI_MEM.AXI_MMU.S_AXIL_QEMU_MQ
+  for(i <- 0 until devteroFlexTop.AXI_MEM.AXI_MMU.M_DMA_R.length)
+    axiMulti_R.S_IF(i) <> devteroFlexTop.AXI_MEM.AXI_MMU.M_DMA_R(i)
+  for(i <- 0 until devteroFlexTop.AXI_MEM.AXI_MMU.M_DMA_W.length)
+    axiMulti_W.S_IF(i) <> devteroFlexTop.AXI_MEM.AXI_MMU.M_DMA_W(i)
+  var W_IDX = devteroFlexTop.AXI_MEM.AXI_MMU.M_DMA_W.length
+  var R_IDX = devteroFlexTop.AXI_MEM.AXI_MMU.M_DMA_R.length
+  axiMulti_W.S_IF(W_IDX+0) <> devteroFlexTop.AXI_MEM.M_AXI_DMA_icacheW
+  axiMulti_W.S_IF(W_IDX+1) <> devteroFlexTop.AXI_MEM.M_AXI_DMA_dcacheW
+  axiMulti_R.S_IF(R_IDX+0) <> devteroFlexTop.AXI_MEM.M_AXI_DMA_icacheR
+  axiMulti_R.S_IF(R_IDX+1) <> devteroFlexTop.AXI_MEM.M_AXI_DMA_dcacheR
+
+  val M_AXI = IO(new AXI4(paramsMemoryHierarchy.dramAddrW, paramsMemoryHierarchy.cacheBlockSize))
+  // Interconnect Read ports
+  M_AXI.ar <> axiMulti_R.M_AXI.ar
+  M_AXI.r <> axiMulti_R.M_AXI.r
+  // Disable Write ports
+  axiMulti_R.M_AXI.aw <> AXI4AW.stub(paramsMemoryHierarchy.dramAddrW)
+  axiMulti_R.M_AXI.w <> AXI4W.stub(paramsMemoryHierarchy.cacheBlockSize)
+  axiMulti_R.M_AXI.b <> AXI4B.stub()
+  // Interconnect Write ports
+  M_AXI.aw <> axiMulti_W.M_AXI.aw
+  M_AXI.w <> axiMulti_W.M_AXI.w
+  M_AXI.b <> axiMulti_W.M_AXI.b
+  // Disable Read ports
+  axiMulti_W.M_AXI.ar <> AXI4AR.stub(paramsMemoryHierarchy.dramAddrW)
+  axiMulti_W.M_AXI.r <> AXI4R.stub(paramsMemoryHierarchy.cacheBlockSize)
+
+  // Instrumentation to store PC
+  val traceWrapper = Module(new TraceWrapper(
+    paramsMemoryHierarchy.dramAddrW, axilMulti.S_AXIL.addrWidth, 0x1F000))
+  traceWrapper.commit.bits <> devteroFlexTop.instrument.commit.bits.pc
+  traceWrapper.commit.handshake(devteroFlexTop.instrument.commit)
+  axilMulti.M_AXIL(2) <> traceWrapper.S_AXIL
+  axiMulti_W.S_IF(W_IDX+2) <> traceWrapper.M_AXI_W
+}
+
+class TraceWrapper(val dramAddrW: Int, val axilAddrW: Int, val axilBaseAddr: Int) extends MultiIOModule {
+  val S_AXIL = IO(Flipped(new AXI4Lite(axilAddrW, 32))) 
+  val M_AXI_W = IO(new AXIWriteMasterIF(dramAddrW, 512))
+  val commit = IO(Flipped(Decoupled(UInt(64.W))))
+
+  private val traceDumper = Module(new TraceDump(new TraceDumpParams(dramAddrW, 512, 64, 1024, 256, 32)))
+  private val dramPortTransformer = Module(new DRAMWrapperWrite(new DRAMPortParams(dramAddrW, 512)))
+  private val nCSR = 6
+  private val uAxilToCSR = Module(new AXI4LiteCSR(32, nCSR))
+  private val cfgBusCSR = new CSRBusSlave(0, nCSR)
+  private val uCSR = Module(new CSR(32, nCSR))
+  uAxilToCSR.io.ctl <> S_AXIL
+  uCSR.io.bus <> uAxilToCSR.io.bus
+
+  private val clearToggle = WireInit(VecInit(0.U(32.W).asBools))
+  private val baseAddrCSR = SimpleCSR(uCSR.io.csr(0), 32)
+  private val start = ClearCSR(clearToggle.asUInt, uCSR.io.csr(1), 32)
+
+  traceDumper.init_addr.bits := baseAddrCSR
+  traceDumper.init_addr.valid := start(0)
+  clearToggle(0) := traceDumper.init_addr.ready
+
+  traceDumper.trace_data.bits := commit.bits
+  traceDumper.trace_data.handshake(commit)
+  when(traceDumper.init_addr.ready) {
+    commit.ready := true.B // Hasn't been enabled yet, let it run
+  }
+
+  private val cntExecute = Module(new PerfCounter(32))
+  private val cntStalls = Module(new PerfCounter(32))
+  StatusCSR(cntExecute.io.count, uCSR.io.csr(2), 32)
+  StatusCSR(cntStalls.io.count, uCSR.io.csr(3), 32)
+  private val enableCntCSR = SimpleCSR(uCSR.io.csr(4), 32)
+  clearToggle(1) := true.B // Always clear toggle start signal
+  cntExecute.io.reset := start(1)
+  cntStalls.io.reset := start(1)
+  cntExecute.io.incr := traceDumper.trace_data.fire && enableCntCSR(0)
+  cntStalls.io.incr := !traceDumper.trace_data.fire && enableCntCSR(0)
+
+  private val cntBursts = Module(new PerfCounter(32))
+  StatusCSR(cntBursts.io.count, uCSR.io.csr(5), 32)
+  cntBursts.io.reset := start(1)
+  cntBursts.io.incr := traceDumper.dram_write_port.req.fire
+
+  dramPortTransformer.write <> traceDumper.dram_write_port
+  M_AXI_W <> dramPortTransformer.M_AXI_W
+}
+
+object ARMFlexInstrumentedVerilogEmitter extends App {
+  val c = new chisel3.stage.ChiselStage
+  import java.io._
+  val fr = new FileWriter(new File("regression/rtl/ARMFlexTop.v"))
+  fr.write(c.emitVerilog(
+    new ARMFlexTopInstrumented(
+      new PipelineParams(thidN = 8, pAddrW =  24),
+      new MemoryHierarchyParams(thidN = 8, pAddrW = 24)
+      ), annotations = Seq(TargetDirAnnotation("regression/rtl/"))))
+  fr.close()
+}

--- a/src/main/scala/armflex/Commit.scala
+++ b/src/main/scala/armflex/Commit.scala
@@ -47,6 +47,10 @@ class CommitArchStateIO(thidN: Int) extends Bundle {
   val ready = Input(Bool())
 }
 
+class CommitInstrument(thidN: Int) extends Bundle {
+  val pc = DATA_T
+}
+
 class CommitUnit(thidN: Int) extends Module {
   val enq = IO(Flipped(Decoupled(new CommitInst(thidN))))
   val commit = IO(new Bundle {
@@ -90,8 +94,9 @@ class CommitUnit(thidN: Int) extends Module {
   commit.archstate.wr.tag := tag
 
   // WriteBack
+  val instrumentReady = Wire(Bool())
   val s_WB :: s_WB1 :: s_WB2 :: Nil = Enum(3)
-  val canWB = WireInit(commit.archstate.ready && commitQueue.io.deq.valid)
+  val canWB = WireInit(commit.archstate.ready && commitQueue.io.deq.valid && instrumentReady)
   val wbState = RegInit(s_WB)
   val wbState_next = WireInit(wbState)
   wbState := wbState_next
@@ -123,7 +128,8 @@ class CommitUnit(thidN: Int) extends Module {
     }
   }
 
-  commitQueue.io.deq.ready := canWB && wbState_next === s_WB
+  val lastCommitCycle = WireInit(canWB && wbState_next === s_WB)
+  commitQueue.io.deq.ready := lastCommitCycle
   val finalCommit = WireInit(commitQueue.io.deq.fire)
   commit.commited.tag := tag
   commit.commited.valid := finalCommit
@@ -141,4 +147,12 @@ class CommitUnit(thidN: Int) extends Module {
       }
     }
   }
+
+  // Instrumentation interface
+  val deq = IO(Decoupled(new CommitInstrument(thidN)))
+  instrumentReady := deq.ready
+  deq.valid := lastCommitCycle
+  deq.bits.pc := commit.archstate.regs.curr.PC
+
+  assert((commitQueue.io.deq.fire && deq.fire) || (!commitQueue.io.deq.fire && !deq.fire), "Both deq and commitQueue must dequeue at the same time")
 }

--- a/src/main/scala/armflex/Pipeline.scala
+++ b/src/main/scala/armflex/Pipeline.scala
@@ -246,6 +246,12 @@ class Pipeline(params: PipelineParams) extends Module {
   decReg.io.flush.tag := DontCare
   issuer.io.flush.tag := DontCare
 
+  // Instrumentation Interface -----------------------------------------------
+  val instrument = IO(new Bundle {
+    val commit = commitU.deq.cloneType
+  })
+  instrument.commit <> commitU.deq
+
   // DEBUG Signals ------------------------------------------------------------
   val dbg = IO(new Bundle {
     val issue = Output(new Bundle {

--- a/src/main/scala/armflex/PipelineWithTransplant.scala
+++ b/src/main/scala/armflex/PipelineWithTransplant.scala
@@ -41,7 +41,7 @@ class PipelineAxi(params: PipelineParams) extends Module {
   private val axiAddr_range = (0, 0xA000)
   private val csrAddr_range = (axiAddr_range._1 >> 2, axiAddr_range._2 >> 2)
 
-  private val pipeline = Module(new PipelineWithTransplant(params))
+  val pipeline = Module(new PipelineWithTransplant(params))
 
   private val uAxilToCSR = Module(new AXI4LiteCSR(params.axiDataW, csrAddr_range._2 - csrAddr_range._1))
 
@@ -90,6 +90,10 @@ class PipelineAxi(params: PipelineParams) extends Module {
 
   uCSRthid2asid.thid_i(1) := pipeline.mem_io.data.tlb.req.bits.thid
   mem_io.data.tlb.req.bits.asid := uCSRthid2asid.asid_o(1).bits
+
+  // Instrumentation Interface
+  val instrument = IO(pipeline.instrument.cloneType)
+  instrument <> pipeline.instrument
 
   if(true) {// TODO conditional assertions
     when(pipeline.mem_io.data.tlb.req.valid){
@@ -166,6 +170,10 @@ class PipelineWithTransplant(params: PipelineParams) extends Module {
   transplantU.trans2host <> hostIO.trans2host
   transplantU.hostBramPort <> hostIO.port
   pipeline.transplantIO.stopCPU := transplantU.cpu2trans.stopCPU
+
+  // Instrumentation interface
+  val instrument = IO(pipeline.instrument.cloneType)
+  instrument <> pipeline.instrument
 
   if(false) { // TODO Conditional assertions and printing
     when(archstate.pstate.commit.next.valid) {

--- a/src/main/scala/instrumentation/TraceDump.scala
+++ b/src/main/scala/instrumentation/TraceDump.scala
@@ -1,0 +1,166 @@
+package instrumentation
+
+import chisel3._
+import chisel3.util._
+import antmicro.CSR._
+import antmicro.Bus._
+import arm._
+import armflex._
+import armflex.util.ExtraUtils._
+import armflex.util.{AXIReadMasterIF, AXIReadMultiplexer, AXIWriteMasterIF, AXIWriteMultiplexer, BRAM, BRAMParams, ReadPort, WritePort}
+import armflex_mmu.MemoryHierarchyParams
+import javax.script.Bindings
+
+class TraceDumpParams(
+  val addrW: Int = 12,
+  val dataW: Int = 512,
+  val traceW: Int = 64,
+  val bramSize: Int = 1024,
+  val windowSize: Int = 256,
+  val burstSize: Int = 1,
+)
+
+class TraceDump(val params: TraceDumpParams) extends MultiIOModule {
+  val init_addr = IO(Flipped(Decoupled(UInt(params.addrW.W))))
+  val trace_data = IO(Flipped(Decoupled(UInt(params.traceW.W))))
+  val dram_write_port = IO(Flipped(new WritePort(params.addrW, params.dataW)))
+
+  private val WORDS_PER_BLOCK = params.dataW / params.traceW
+  private val bramBufferData = new BRAMParams(
+    NB_COL = params.dataW/8, COL_WIDTH = 8, NB_ELE = params.bramSize,
+    INIT_FILE = "", false, false, true, false)
+
+  private val b_Buffering :: b_Full :: Nil = Enum(2)
+  private val buffer_state = RegInit(b_Buffering)
+
+  private val s_Idle :: s_Packing :: s_Prepare :: s_Write :: Nil = Enum(4)
+  private val step = RegInit(s_Idle)
+
+  private val block_buffer = RegInit(VecInit(Seq.fill(WORDS_PER_BLOCK)(0.U.asTypeOf(trace_data.bits))))
+  private val curr_word = RegInit(0.U(log2Ceil(WORDS_PER_BLOCK).W))
+  private val writes_pending = RegInit(0.U(log2Ceil(params.bramSize).W))
+
+  private val bram = Module(new BRAM()(bramBufferData))
+  private val curr_block_in = RegInit(0.U((log2Ceil(params.burstSize) + 1).W))
+  private val curr_block_out = RegInit(0.U((log2Ceil(params.burstSize) + 1).W))
+  private val bram_in_addr = RegInit(0.U.asTypeOf(bram.portA.ADDR))
+  private val bram_out_addr = RegInit(0.U.asTypeOf(bram.portB.ADDR))
+  private val bram_full = RegInit(false.B)
+
+  private val init_addr_reg = RegInit(0.U.asTypeOf(init_addr.bits))
+  private val curr_addr = RegInit(0.U.asTypeOf(init_addr.bits))
+
+  bram.portA.ADDR := RegNext(bram_in_addr)
+  bram.portA.DI := block_buffer.asUInt()
+  bram.portA.EN := true.B
+  bram.portA.WE := RegNext(Fill(bram.portA.WE.getWidth, !bram_full))
+
+  bram.portB.ADDR := bram_out_addr
+  bram.portB.DI := DontCare
+  bram.portB.EN := true.B
+  bram.portB.WE := false.B
+
+  dram_write_port.data.valid := step === s_Write
+  dram_write_port.data.bits := bram.portB.DO
+  dram_write_port.req.valid := step === s_Prepare
+  dram_write_port.req.bits.w_en := Fill(dram_write_port.req.bits.w_en.getWidth, 1.U.asUInt())
+  dram_write_port.req.bits.addr := curr_addr << log2Ceil(params.dataW/8).U // Address is byte addressed, not block
+  dram_write_port.req.bits.burst := params.burstSize.U
+
+  trace_data.ready := (buffer_state === b_Buffering && step =/= s_Idle) || step === s_Idle
+  switch(buffer_state) {
+    is(b_Buffering) {
+      when(trace_data.fire) {
+        block_buffer(curr_word) := trace_data.bits
+        when(curr_word === (WORDS_PER_BLOCK - 1).U) {
+          curr_word := 0.U
+
+          when(curr_block_in === (params.burstSize - 1).U) {
+            curr_block_in := 0.U
+            writes_pending := writes_pending + 1.U
+          }.otherwise {
+            curr_block_in := curr_block_in + 1.U
+          }
+
+          when(bram_full) {
+            buffer_state := b_Full
+          }.otherwise {
+            bram_in_addr := bram_in_addr + 1.U
+            when(bram_in_addr + 1.U === bram_out_addr) {
+              bram_full := true.B
+            }
+          }
+        }.otherwise {
+          curr_word := curr_word + 1.U
+        }
+      }
+    }
+    is(b_Full) {
+      when(!bram_full) {
+        bram_in_addr := bram_in_addr + 1.U
+        when(bram_in_addr + 1.U === bram_out_addr) {
+          bram_full := true.B
+        }
+        buffer_state := b_Buffering
+      }
+    }
+  }
+
+  init_addr.ready := step === s_Idle
+  switch(step) {
+    is(s_Idle) {
+      when(init_addr.fire) {
+        init_addr_reg := init_addr.bits
+        curr_addr := init_addr.bits
+        step := s_Packing
+      }
+    }
+    is(s_Packing) {
+      when(writes_pending > 0.U) {
+        writes_pending := writes_pending - 1.U
+        step := s_Prepare
+      }
+    }
+    is(s_Prepare) {
+      when(dram_write_port.req.fire) {
+        step := s_Write
+      }
+    }
+    is(s_Write) {
+      when(dram_write_port.data.fire) {
+        bram_out_addr := bram_out_addr + 1.U
+        bram_full := false.B
+
+        when(curr_block_out === (params.burstSize - 1).U) {
+          curr_block_out := 0.U
+          step := s_Packing
+
+          when(curr_addr === init_addr_reg + (params.windowSize - params.burstSize).U) {
+            curr_addr := init_addr_reg
+          }.otherwise {
+            curr_addr := curr_addr + params.burstSize.U
+          }
+        }.otherwise{
+          curr_block_out := curr_block_out + 1.U
+        }
+      }
+    }
+  }
+
+  assert(params.dataW % params.traceW == 0, "Data width must be divisible by the trace width")
+  assert(log2Ceil(params.bramSize) == log2Floor(params.bramSize), "BRAM size must be a power of 2")
+  assert(params.bramSize % params.burstSize == 0, "BRAM size must be divisible by the burst size")
+  assert(bram.portA.ADDR.getWidth == log2Ceil(params.bramSize), "bram_in_addr width != log2(bramSize)")
+  assert(bram.portB.ADDR.getWidth == log2Ceil(params.bramSize), "bram_out_addr width != log2(bramSize)")
+}
+
+object TraceDumpTopVerilogEmitter extends App {
+  val c = new chisel3.stage.ChiselStage
+
+  import java.io._
+  import firrtl.options.TargetDirAnnotation
+
+  c.emitVerilog(
+    new TraceDump(new TraceDumpParams()
+    ), annotations = Seq(TargetDirAnnotation("test/example/")))
+}

--- a/src/main/scala/util/MemoryHelpers.scala
+++ b/src/main/scala/util/MemoryHelpers.scala
@@ -3,6 +3,8 @@ package armflex.util
 import chisel3._
 import chisel3.util._
 
+import armflex.util.ExtraUtils._
+
 class MemReqBurst(
     val addrW: Int,
     val dataW: Int,
@@ -29,4 +31,32 @@ class WritePort(
 ) extends Bundle {
     val req = Flipped(Decoupled(new MemReqBurst(addrW, dataW, burstS)))
     val data = Flipped(Decoupled(UInt(dataW.W)))
+}
+
+class DRAMPortParams(
+  val pAddrW: Int = 12,
+  val pDataW: Int = 512
+)
+class DRAMWrapperWrite(val params: DRAMPortParams) extends MultiIOModule {
+  assert(params.pDataW == 512, "Assumes that we match AWS F1 DRAM width.")
+  val M_AXI_W = IO(new AXIWriteMasterIF(params.pAddrW, params.pDataW))
+  // The write port allows for burst data writes
+  val write = IO(new WritePort(params.pAddrW, params.pDataW))
+
+  M_AXI_W.req.bits.address := write.req.bits.addr
+  M_AXI_W.req.bits.length := write.req.bits.burst
+  M_AXI_W.req.handshake(write.req)
+  M_AXI_W.data <> write.data
+}
+
+class DRAMWrapperRead(val params: DRAMPortParams) extends MultiIOModule {
+  assert(params.pDataW == 512, "Assumes that we match AWS F1 DRAM width.")
+  val M_AXI_R = IO(new AXIReadMasterIF(params.pAddrW, params.pDataW))
+
+  // The read port allows for burst data writes
+  val read = IO(new ReadPort(params.pAddrW, params.pDataW))
+  M_AXI_R.req.bits.address := read.req.bits.addr
+  M_AXI_R.req.bits.length := read.req.bits.burst
+  M_AXI_R.req.handshake(read.req)
+  read.data <> M_AXI_R.data
 }

--- a/src/test/scala/instrumentation/TopLevelTest.scala
+++ b/src/test/scala/instrumentation/TopLevelTest.scala
@@ -14,6 +14,7 @@ import firrtl.options.TargetDirAnnotation
 import java.nio.ByteBuffer
 
 import InstrumentationDrivers._
+import armflex.util.{DRAMPortParams}
 object InstrumentationDrivers {
   abstract class DriverBase[T <: Module](target: T) {
     implicit val clock = target.clock
@@ -90,7 +91,7 @@ class TestInstrumentationExample extends AnyFlatSpec with ChiselScalatestTester 
 
   it should "Test Pushing and Pulling a memory block" in {
     test(new TopLevelExample(new TopLevelExampleParams(
-      new DRAMExampleParams(12, 512),
+      new DRAMPortParams(12, 512),
       new CSRExampleParams(32),
       new ComputeExampleParams(12, 512)
     ))).withAnnotations(annos) {

--- a/src/test/scala/instrumentation/TraceDumpTest.scala
+++ b/src/test/scala/instrumentation/TraceDumpTest.scala
@@ -1,0 +1,129 @@
+package instrumentation
+
+import chisel3._
+import chiseltest._
+import chiseltest.internal._
+import chiseltest.experimental.TestOptionBuilder._
+import chisel3.util.Cat
+import armflex.util.AXIDrivers.AXI4LiteDriver
+import armflex.util.MemHelperDrivers._
+import armflex.util.SoftwareStructs._
+import org.scalatest.FlatSpec
+import firrtl.options.TargetDirAnnotation
+import java.nio.ByteBuffer
+
+import InstrumentationDrivers._
+import instrumentation.TraceDumpDrivers.TraceDumpTestSimple
+
+import scala.collection.compat.immutable.ArraySeq
+object TraceDumpDrivers {
+  abstract class DriverBase[T <: MultiIOModule](target: T) {
+    implicit val clock = target.clock
+  }
+
+  implicit class TraceDumpDriver(target: TraceDump) extends DriverBase(target) {
+    def init() {
+      target.trace_data.setSourceClock(clock)
+      target.init_addr.setSourceClock(clock)
+      target.dram_write_port.init()
+    }
+
+    def step(i : Int): Unit = {
+      clock.step(i)
+    }
+
+    def sendWriteBurst(pcs: Seq[Long]): Unit = {
+      for(pc <- pcs) {
+        target.trace_data.enqueue(pc.U)
+        clock.step(pc.toInt)
+      }
+    }
+
+    def startMemWrite(expectedAddr: Long, expectedData: Seq[Long]): Unit = {
+      val data = expectedData.grouped(512/64).map{
+        seqInt =>
+          val byteBuffers = seqInt.reverse.map {
+            int => ByteBuffer.allocate(8).putLong(int).array()
+          }
+          BigInt(0.toByte +: byteBuffers.flatten.toArray)
+      }
+      target.dram_write_port.req.valid.expect(true.B)
+      target.dram_write_port.expect(expectedAddr, target.params.burstSize, data.toSeq)
+    }
+  }
+
+  class TraceDumpTestSimple(dut: TraceDump){
+    def run() {
+      dut.init()
+      val pcs1: Seq[Long] = ArraySeq(6, 5, 6, 14, 1, 5, 3, 2)
+      val pcs2: Seq[Long] = ArraySeq(1, 11, 9, 3, 17, 13, 2, 7)
+      val init_addr: Long = 0x0
+      dut.init_addr.enqueue(init_addr.U)
+      dut.step(3)
+      for(i <- 0 to 7) {
+        val pcs: Seq[Long] = if(i % 2 == 0) pcs1 else pcs2
+        dut.sendWriteBurst(pcs)
+        dut.startMemWrite(init_addr + i, pcs)
+        dut.step(5)
+      }
+      dut.sendWriteBurst(pcs1)
+      dut.sendWriteBurst(pcs2)
+      dut.startMemWrite(init_addr, pcs1)
+      dut.step(5)
+      dut.startMemWrite(init_addr + 1, pcs2)
+    }
+
+    def runMultiBurst() {
+      dut.init()
+      val pcs1: Seq[Long] = ArraySeq(6, 5, 6, 14, 1, 5, 3, 2)
+      val pcs2: Seq[Long] = ArraySeq(1, 11, 9, 3, 17, 13, 2, 7)
+      val pcs3: Seq[Long] = ArraySeq(5, 7, 15, 2, 1, 1, 12, 9)
+      val init_addr: Long = 0x0
+      dut.init_addr.enqueue(init_addr.U)
+      dut.step(3)
+      for(i <- 0 to 3) {
+        dut.sendWriteBurst(pcs1)
+        dut.sendWriteBurst(pcs2)
+        dut.startMemWrite(init_addr + 2 * i, pcs1)
+        dut.startMemWrite(init_addr + 2 * i, pcs2)
+        dut.step(5)
+      }
+      dut.sendWriteBurst(pcs1)
+      dut.sendWriteBurst(pcs2)
+      dut.sendWriteBurst(pcs3)
+      dut.startMemWrite(init_addr, pcs1)
+      dut.step(5)
+      dut.startMemWrite(init_addr, pcs2)
+      dut.step(10)
+      dut.sendWriteBurst(pcs1)
+      dut.startMemWrite(init_addr + 2, pcs3)
+      dut.startMemWrite(init_addr + 2, pcs1)
+    }
+
+    def runStressTest() {
+      dut.init()
+      val init_addr: Long = 0x0
+      dut.init_addr.enqueue(init_addr.U)
+      dut.step(3)
+      for(i <- 0 to 8199) {
+        println(i)
+        dut.trace_data.enqueue(i.U)
+      }
+    }
+  }
+}
+
+class TestTraceDump extends FlatSpec with ChiselScalatestTester {
+  val annos = Seq(VerilatorBackendAnnotation, TargetDirAnnotation("test/instrumentation"), WriteVcdAnnotation)
+
+
+  behavior of "DevteroFlex Instrumentation Example"
+
+  it should "Test Pushing and Pulling a memory block" in {
+    test(new TraceDump(new TraceDumpParams(windowSize = 8, burstSize = 2))).withAnnotations(annos) {
+      dut =>
+        val dutDriver = new TraceDumpTestSimple(dut)
+        dutDriver.runMultiBurst()
+    }
+  }
+}


### PR DESCRIPTION
Extract signals from commit stage in order to instrument them.

In this example every time a thread updated the PC, it will get buffered to BRAM and then pushed to DRAM.