### PR TITLE
Refactor transplant to remove axi-axil assumed dependencies

### DIFF
--- a/Devteroflex/src/ARMFlexTop.scala
+++ b/Devteroflex/src/ARMFlexTop.scala
@@ -128,7 +128,7 @@ class ARMFlexTop(
   S_AXIL <> uAXIL2CSR.io.ctl
   val uCSRMux = Module(new CSRBusMasterToNSlaves(32, Seq(
     new CSRBusSlaveConfig(0, 0x100),
-    new CSRBusSlaveConfig(0x100, 4),
+    new CSRBusSlaveConfig(0x100, TransplantConsts.TRANS_REG_TOTAL_REGS),
     new CSRBusSlaveConfig(0x200, 4)
   ), (0, 0x300)))
   uCSRMux.masterBus <> uAXIL2CSR.io.bus

--- a/Devteroflex/src/ARMFlexTop.scala
+++ b/Devteroflex/src/ARMFlexTop.scala
@@ -132,7 +132,7 @@ class ARMFlexTop(
     new CSRBusSlaveConfig(0x200, 4)
   ), (0, 0x300)))
   uCSRMux.masterBus <> uAXIL2CSR.io.bus
-  uCSRMux.slavesBus(0) <> u_pipeline.S_CSR_TreadTable
+  uCSRMux.slavesBus(0) <> u_pipeline.S_CSR_ThreadTable
   uCSRMux.slavesBus(1) <> u_pipeline.S_CSR_Pipeline
   uCSRMux.slavesBus(2) <> memory.S_CSR
 

--- a/Devteroflex/src/Antmicro/CSR/ClearCSR.scala
+++ b/Devteroflex/src/Antmicro/CSR/ClearCSR.scala
@@ -57,6 +57,16 @@ object ClearCSR {
   }
 }
 
+object PulseCSR {
+  def apply(csrCtl: CSRRegBundle, dataWidth: Int): UInt = {
+    val csr = Module(new ClearCSR(dataWidth))
+
+    csr.io.clear := chisel3.util.Fill(dataWidth, 1.U)
+    csr.io.csr <> csrCtl
+    csr.io.value
+  }
+}
+
 import chisel3.util.{Valid, log2Ceil}
 class ClearReg(dataWidth: Int) extends Module{
   val io = IO(new Bundle{

--- a/Devteroflex/src/Antmicro/CSR/StatusCSR.scala
+++ b/Devteroflex/src/Antmicro/CSR/StatusCSR.scala
@@ -45,3 +45,21 @@ object StatusCSR{
     csr.io.value := status
   }
 }
+
+object StatusVecCSR {
+  def apply(vec: Vec[UInt], bus: CSRBusBundle, dataWidth: Int) = {
+    val csrVec = Module(new StatusVecCSR(vec.size, dataWidth))
+    csrVec.io.vec := vec
+    csrVec.io.bus := bus 
+  }
+}
+
+class StatusVecCSR(regCount: Int, dataWidth: Int) extends Module {
+  val io = IO(new Bundle {
+    val bus = Flipped(new CSRBusBundle(dataWidth, regCount))
+    val vec = Input(Vec(regCount, UInt(dataWidth.W)))
+  })
+
+  val data = WireInit(0.U(dataWidth.W))
+  io.bus.dataIn := io.vec(io.bus.addr)
+}

--- a/Devteroflex/src/arm/ProcTypes.scala
+++ b/Devteroflex/src/arm/ProcTypes.scala
@@ -11,6 +11,11 @@ object PROCESSOR_TYPES
   def DATA_T = UInt(DATA_W)
   val DATA_X = 0.U(DATA_W)
 
+  // Block Size
+  val BLOCK_SZ = 512
+  val regsPerBlock = BLOCK_SZ/DATA_SZ
+  val BYTES_PER_BLOCK = BLOCK_SZ/8
+ 
   // Inst
   val INST_SZ = 32
   val INST_W = INST_SZ.W

--- a/Devteroflex/src/armflex/PState.scala
+++ b/Devteroflex/src/armflex/PState.scala
@@ -28,6 +28,7 @@ import armflex.util._
  */
 
 class PStateFlags extends Bundle {
+  val execMode = UInt(2.W)
   val isICountDepleted = Bool()
   val isUndef = Bool()
   val isException = Bool()
@@ -56,6 +57,10 @@ object PStateConsts {
   val TRANS_STATE_THID_MAX_BYTES = (512) // 8 512-bit blocks; Pad to next power of two 
   val TRANS_STATE_THID_MAX_REGS  = (512/8) // 8 512-bit blocks; Pad to next power of two 
   val TRANS_STATE_regsPerBlock = (512/64) // 8 64-bit regs in a 512-bit block
+
+  val PSTATE_FLAGS_EXECUTE_SINGLESTEP = (2)
+  val PSTATE_FLAGS_EXECUTE_NORMAL     = (1)
+  val PSTATE_FLAGS_EXECUTE_WAIT       = (0)
 }
 
 object PStateRegs {

--- a/Devteroflex/src/armflex/PState.scala
+++ b/Devteroflex/src/armflex/PState.scala
@@ -41,20 +41,27 @@ class PStateRegs extends Bundle {
   val PC = DATA_T
 }
 
+object PStateConsts {
+  val ARCH_PSTATE_XREGS_OFFST  = (0)
+  val ARCH_PSTATE_PC_OFFST     = (32)
+  val ARCH_PSTATE_FLAGS_OFFST  = (33)
+  val ARCH_PSTATE_ICOUNT_OFFST = (34)
+  val ARCH_PSTATE_TOT_REGS     = (35)
+
+  val TRANS_STATE_PState_OFFST   = (32)  // Contains PC, flags, and icount
+  val TRANS_STATE_SIZE_BYTES     = (320) // 5 512-bit blocks; Full state fits in this amount of bytes
+  val TRANS_STATE_THID_MAX_BYTES = (512) // 8 512-bit blocks; Pad to next power of two 
+  val TRANS_STATE_THID_MAX_REGS  = (512/8) // 8 512-bit blocks; Pad to next power of two 
+  val TRANS_STATE_regsPerBlock = (512/64) // 8 64-bit regs in a 512-bit block
+}
+
 object PStateRegs {
   def apply(): PStateRegs = {
-    val wire = Wire(new PStateRegs)
-    wire.PC := DATA_X
-    wire.flags.NZCV := NZCV_X
-    wire.flags.isException := false.B
-    wire.flags.isUndef := false.B
-    wire.flags.isICountDepleted := false.B
-    wire.icount := 0.U
-    wire.icountBudget := 0.U
+    val wire = WireInit(new PStateRegs, 0.U.asTypeOf(new PStateRegs))
     wire
   }
-  def getNZCV(bits: UInt): UInt = bits(3, 0)
 }
+
 object RFileIO {
   class RDPort(thidN: Int) extends Bundle {
     val port = Vec(3, new Bundle {

--- a/Devteroflex/src/armflex/PipelineWithTransplant.scala
+++ b/Devteroflex/src/armflex/PipelineWithTransplant.scala
@@ -40,9 +40,11 @@ class PipelineParams(
 import antmicro.Bus.AXI4Lite
 
 class PipelineWithCSR(params: PipelineParams) extends Module {
-  private val uCSRthid2asid = Module(new CSR_thid2asid(params.thidN, params.asidW, thid2asidPortsN = 2))
-  val S_CSR_TreadTable = IO(Flipped(uCSRthid2asid.bus.cloneType))
-  S_CSR_TreadTable <> uCSRthid2asid.bus
+  // TODO: Not used anyways as we rely on another mechanism, we could remove this
+  private val uCSRVecAsid = Module(new StatusVecCSR(params.thidN, params.axiDataW))
+  val S_CSR_ThreadTable = IO(Flipped(uCSRVecAsid.io.bus.cloneType))
+  S_CSR_ThreadTable <> uCSRVecAsid.io.bus
+  uCSRVecAsid.io.vec := 0.U.asTypeOf(uCSRVecAsid.io.vec.cloneType)
 
   val pipeline = Module(new PipelineWithTransplant(params))
   val S_CSR_Pipeline = IO(Flipped(pipeline.hostIO.S_CSR.cloneType))

--- a/Devteroflex/src/armflex/PipelineWithTransplant.scala
+++ b/Devteroflex/src/armflex/PipelineWithTransplant.scala
@@ -111,7 +111,7 @@ class PipelineWithTransplant(params: PipelineParams) extends Module {
   archstate.pstateIO.commit <> pipeline.archstate.commit
 
   // Update State - Highjack commit ports from pipeline
-  archstate.pstateIO.transplant.thread := transplantU.trans2cpu.thread
+  archstate.pstateIO.transplant.thread := transplantU.trans2cpu.start.bits
   
   pipeline.archstate.commit.ready := archstate.pstateIO.commit.ready && 
                                     !transplantU.trans2cpu.stallPipeline && 
@@ -133,7 +133,7 @@ class PipelineWithTransplant(params: PipelineParams) extends Module {
   when(transplantU.trans2cpu.pstate.valid) {
     // PState is from the pipeline.
     archstate.pstateIO.commit.fire := true.B
-    archstate.pstateIO.commit.tag := transplantU.trans2cpu.thread
+    archstate.pstateIO.commit.tag := transplantU.trans2cpu.start.bits
     archstate.pstateIO.commit.pstate.next := transplantU.trans2cpu.pstate.bits
     archstate.pstateIO.commit.isTransplantUnit := true.B
     archstate.pstateIO.commit.isCommitUnit := false.B
@@ -146,8 +146,8 @@ class PipelineWithTransplant(params: PipelineParams) extends Module {
 
   transplantU.cpu2trans.rfile_wr <> pipeline.archstate.commit.wr
   transplantU.cpu2trans.doneCPU := pipeline.transplantIO.done
-  pipeline.transplantIO.start.valid := transplantU.trans2cpu.start
-  pipeline.transplantIO.start.tag := transplantU.trans2cpu.thread
+  pipeline.transplantIO.start.valid := transplantU.trans2cpu.start.valid
+  pipeline.transplantIO.start.tag := transplantU.trans2cpu.start.bits
   pipeline.transplantIO.start.bits.get := transplantU.trans2cpu.pstate.bits.PC
   // Transplant from Host
   transplantU.S_CSR <> hostIO.S_CSR
@@ -197,8 +197,8 @@ class PipelineWithTransplant(params: PipelineParams) extends Module {
     dbg.bits.get.commit.tag := RegNext(pipeline.archstate.commit.tag)
     dbg.bits.get.commit.valid := RegNext(pipeline.archstate.commit.fire)
     dbg.bits.get.commitIsTransplant := RegNext(pipeline.transplantIO.done.valid)
-    dbg.bits.get.transplant.valid := transplantU.trans2cpu.start
-    dbg.bits.get.transplant.tag := transplantU.trans2cpu.thread
+    dbg.bits.get.transplant.valid := transplantU.trans2cpu.start.valid
+    dbg.bits.get.transplant.tag := transplantU.trans2cpu.start.bits
   }
   // */
 }

--- a/Devteroflex/src/armflex/Transplant.scala
+++ b/Devteroflex/src/armflex/Transplant.scala
@@ -48,6 +48,18 @@ object TransplantIO extends Bundle {
     val dataFault = Input(ValidTag(thidN))
   }
 }
+
+object TransplantConsts {
+  // These constants are shared with `fpga_interface.h`
+  val TRANS_REG_OFFST_PENDING          = (0)
+  val TRANS_REG_OFFST_FREE_PENDING     = (0)
+  val TRANS_REG_OFFST_START            = (1)
+  val TRANS_REG_OFFST_STOP_CPU         = (2)
+  val TRANS_REG_OFFST_FORCE_TRANSPLANT = (3)
+}
+
+import armflex.TransplantConsts._
+
 class TransplantUnit(thidN: Int) extends Module {
   val cpu2trans = IO(new TransplantIO.CPU2Trans(thidN))
   val trans2cpu = IO(new TransplantIO.Trans2CPU(thidN))
@@ -59,43 +71,43 @@ class TransplantUnit(thidN: Int) extends Module {
   S_CSR <> uCSR.io.bus
 
   // uCSR[0]: Check whether a thread has its state in the TBRAM and requiring a transplant back.
-  val wCPU2TransDoneMask = Wire(UInt(32.W))
-  SetCSR(wCPU2TransDoneMask, uCSR.io.csr(0), 32)
+  val wCPU2TransDoneMask = WireInit(0.U(32.W))
+  SetCSR(wCPU2TransDoneMask, uCSR.io.csr(TRANS_REG_OFFST_PENDING), 32)
 
   // uCSR[1]: Set to trigger an unpack of the architecture state to the pipeline (BRAM to CPU) and restart the thread.
-  val wB2CDoneMask = Wire(UInt(32.W))
-  val rUnpackRequest = ClearCSR(wB2CDoneMask, uCSR.io.csr(1), 32)
+  val wB2CDoneMask = WireInit(0.U(32.W))
+  val rUnpackRequest = ClearCSR(wB2CDoneMask, uCSR.io.csr(TRANS_REG_OFFST_START), 32)
 
   // uCSR[2]: Set to stop a thread.
-  val wStoppedThreadMask = WireInit(Mux(
-    cpu2trans.doneCPU.valid,
-    1.U << cpu2trans.doneCPU.tag,
-    0.U
-  ))
-  val rStopCPURequest = ClearCSR(wStoppedThreadMask, uCSR.io.csr(2), 32)
+  val wStoppedThreadMask = WireInit(0.U)
+  when(cpu2trans.doneCPU.valid) {
+    wStoppedThreadMask := 1.U << cpu2trans.doneCPU.tag
+  }
+
+  val rStopCPURequest = ClearCSR(wStoppedThreadMask, uCSR.io.csr(TRANS_REG_OFFST_STOP_CPU), 32)
   cpu2trans.stopCPU := rStopCPURequest
 
   // uCSR[3]: Set to enforce a thread to transplant back.
-  val rForceTransplantRequest = ClearCSR("h_ffff_ffff".U, uCSR.io.csr(3), 32)
+  val rForceTransplantRequest = ClearCSR("h_ffff_ffff".U, uCSR.io.csr(TRANS_REG_OFFST_FORCE_TRANSPLANT), 32)
   cpu2trans.forceTransplant := rForceTransplantRequest
 
   // val mem2trans = IO(new TransplantIO.Mem2Trans(thidN))
 
-  private val rCpu2transPending = RegInit(0.U(thidN.W))
-  private val wCpu2transBeingHandled = WireInit(false.B)
+  private val rCpu2TransPending = RegInit(0.U(thidN.W))
+  private val wCpu2TransBeingHandled = WireInit(false.B)
   // At present lower thread always has the highest priority for transplanting. 
-  private val wSelectedC2TRequest = PriorityEncoder(rCpu2transPending)
-  private val wCpu2transHandledReq = WireInit(wCpu2transBeingHandled.asUInt << wSelectedC2TRequest) // always clear the first one. 
+  private val wSelectedCpu2TransReq = PriorityEncoder(rCpu2TransPending)
+  private val wCpu2TransHandledReq = WireInit(wCpu2TransBeingHandled.asUInt << wSelectedCpu2TransReq) // always clear the first one. 
 
   // All possible sources that trigger packing a state.
-  // private val wCpu2transInstFault = Mux(mem2trans.instFault.valid, 1.U << mem2trans.instFault.tag, 0.U)
-  // private val wCpu2transDataFault = Mux(mem2trans.dataFault.valid, 1.U << mem2trans.dataFault.tag, 0.U)
-  private val wCpu2transCpuTrans = Mux(cpu2trans.doneCPU.valid, 1.U << cpu2trans.doneCPU.tag, 0.U)
+  // private val wCpu2TransInstFault = Mux(mem2trans.instFault.valid, 1.U << mem2trans.instFault.tag, 0.U)
+  // private val wCpu2TransDataFault = Mux(mem2trans.dataFault.valid, 1.U << mem2trans.dataFault.tag, 0.U)
+  private val wCpu2TransCpuTrans = Mux(cpu2trans.doneCPU.valid, 1.U << cpu2trans.doneCPU.tag, 0.U)
   // Aggregate all the sources
-  private val wCpu2transInsert = WireInit(wCpu2transCpuTrans)
+  private val wCpu2TransInsert = WireInit(wCpu2TransCpuTrans)
 
   // The final pending register will be new inserted + force - handled.
-  rCpu2transPending := (rCpu2transPending & ~wCpu2transHandledReq) | wCpu2transInsert | rForceTransplantRequest
+  rCpu2TransPending := (rCpu2TransPending & ~wCpu2TransHandledReq) | wCpu2TransInsert | rForceTransplantRequest
 
   // The state machine of copying data.
   // BRAM to CPU (B2C): Copy all registers, and then copy the PState
@@ -117,96 +129,92 @@ class TransplantUnit(thidN: Int) extends Module {
         rSyncState := sTSyncingB2CXReg
         rCurrentSyncReg := 0.U
         rSyncThread := PriorityEncoder(rUnpackRequest)
-      }.elsewhen(rCpu2transPending =/= 0.U){
+      }.elsewhen(rCpu2TransPending =/= 0.U){
         rSyncState := sTSyncingC2BPState
         rCurrentSyncReg := 0.U
-        rSyncThread := wSelectedC2TRequest
+        rSyncThread := wSelectedCpu2TransReq
       }
     }
 
+    // Can only write a single register at a time
     is(sTSyncingB2CXReg){
       rCurrentSyncReg := rCurrentSyncReg + 1.U
-      rSyncState := Mux(
-        rCurrentSyncReg === (REG_N - 1).U,
-        sTSyncingB2CPState,
-        sTSyncingB2CXReg
-      )
-      assert(uTransplantBRAM.iReadRequest.ready)
+      when(rCurrentSyncReg === (REG_N - 1).U) {
+        rSyncState := sTSyncingB2CPState
+      }
     }
 
-    is(sTSyncingB2CPState){
-      rSyncState := sTIdle
-      assert(uTransplantBRAM.iReadPStateRequest.ready)
+    // PState fits in a single 512-bit block transaction 
+    is(sTSyncingB2CPState) { 
+      // Clear the CSR[1] when done
+      wB2CDoneMask := 1.U << rSyncThread
+      rSyncState := sTIdle 
     }
-
-    is(sTSyncingC2BPState){
-      rSyncState := sTIdle
-      assert(uTransplantBRAM.iPstateWriteRequest.ready)
+    is(sTSyncingC2BPState) { 
+      // Set CSR[] when done
+      wCPU2TransDoneMask := 1.U << rSyncThread
+      rSyncState := sTIdle 
     }
   }
 
   // The CPU2BRAM request will be handed when the syncing unit is idle, and there is no request from the BRAM2CPU.
-  wCpu2transBeingHandled := rSyncState === sTIdle && rUnpackRequest === 0.U && rCpu2transPending =/= 0.U
+  wCpu2TransBeingHandled := rSyncState === sTIdle && rUnpackRequest === 0.U && rCpu2TransPending =/= 0.U
   
-  // CPU2BRAM Logic.
+  // ---------------------- CPU2BRAM -----------------------
+  // ----------- CPU2BRAM --------
   // - determine the write request. The data is write into tht TBRAM. 
-  uTransplantBRAM.iPstateWriteRequest.bits.threadID := rSyncThread
-  uTransplantBRAM.iPstateWriteRequest.bits.state := cpu2trans.pstate
-  uTransplantBRAM.iPstateWriteRequest.valid := rSyncState === sTSyncingC2BPState
+  uTransplantBRAM.ports.wr.thid := rSyncThread
+  uTransplantBRAM.ports.wr.pstate.req.bits.state := cpu2trans.pstate
+  uTransplantBRAM.ports.wr.pstate.req.valid := rSyncState === sTSyncingC2BPState
+
+  // Listen to the pipeline write request and update register inside
+  uTransplantBRAM.ports.wr.xreg.req.bits.regIdx := cpu2trans.rfile_wr.addr
+  uTransplantBRAM.ports.wr.xreg.req.bits.data := cpu2trans.rfile_wr.data
+  uTransplantBRAM.ports.wr.xreg.req.valid := cpu2trans.rfile_wr.en
 
   // stall the pipeline when we decide to write the PState.
-  cpu2trans.stallPipeline := uTransplantBRAM.iPstateWriteRequest.valid
+  cpu2trans.stallPipeline := uTransplantBRAM.ports.wr.pstate.req.valid
 
-  // When CPU2BRAM is done, we need to notify the host that data copies is finished.
-  wCPU2TransDoneMask := Mux(
-    RegNext(uTransplantBRAM.iPstateWriteRequest.valid), 
-    1.U << rSyncThread, 
-    0.U
-  )
-
+  // ----------- BRAM2CPU --------
   // BRAM2CPU Logic
+  uTransplantBRAM.ports.rd.thid := rSyncThread
   // - determine the read port. It's from the TBRAM
-  uTransplantBRAM.iReadRequest.bits.threadID := rSyncThread
-  uTransplantBRAM.iReadRequest.bits.registerIndex := rCurrentSyncReg
-  uTransplantBRAM.iReadRequest.valid := rSyncState === sTSyncingB2CXReg
+  uTransplantBRAM.ports.rd.xreg.req.bits.regIdx := rCurrentSyncReg
+  uTransplantBRAM.ports.rd.xreg.req.valid := rSyncState === sTSyncingB2CXReg
 
   // - Which is the write port?
-  // First, make the data and address aligned.
-  val rB2CRegIndexAlignedWithRead = Reg(Valid(UInt(log2Ceil(REG_N).W)))
-  rB2CRegIndexAlignedWithRead.bits := rCurrentSyncReg
-  rB2CRegIndexAlignedWithRead.valid := rSyncState === sTSyncingB2CXReg
-
   // For normal registers, it's pretty easy to update them.
-  trans2cpu.rfile_wr.en := rB2CRegIndexAlignedWithRead.valid
-  trans2cpu.rfile_wr.addr := rB2CRegIndexAlignedWithRead.bits
-  trans2cpu.rfile_wr.data := uTransplantBRAM.oReadReply
+  // Make the data and address aligned.
+  trans2cpu.rfile_wr.en := RegNext(rSyncState === sTSyncingB2CXReg)
+  trans2cpu.rfile_wr.addr := RegNext(rCurrentSyncReg)
+  trans2cpu.rfile_wr.data := uTransplantBRAM.ports.rd.xreg.resp
   trans2cpu.rfile_wr.tag := rSyncThread
 
   // For the pstate, we have a special read port.
-  uTransplantBRAM.iReadPStateRequest.bits := rSyncThread
-  uTransplantBRAM.iReadPStateRequest.valid := rSyncState === sTSyncingB2CPState
+  uTransplantBRAM.ports.rd.pstate.req.valid := rSyncState === sTSyncingB2CPState
   trans2cpu.pstate.valid := RegNext(rSyncState === sTSyncingB2CPState)
-  trans2cpu.pstate.bits := uTransplantBRAM.oReadPStateReply
+  trans2cpu.pstate.bits := uTransplantBRAM.ports.rd.pstate.resp
   
   // During the synchronization of ArchState (or the BRAM port is occupied), the pipeline is stalled.
-  trans2cpu.stallPipeline := trans2cpu.pstate.valid || trans2cpu.rfile_wr.en || uTransplantBRAM.iReadRequest.valid || uTransplantBRAM.iReadPStateRequest.valid
+  trans2cpu.stallPipeline := trans2cpu.pstate.valid || trans2cpu.rfile_wr.en 
+          // RegNext(rSyncState === sTSyncingB2CPState) || RegNext(rSyncState === sTSyncingB2CXReg)
 
   // Restart a thread after transfer is done.
   trans2cpu.thread := rSyncThread
   trans2cpu.start := RegNext(rSyncState === sTSyncingB2CPState)
 
-  // Also clear the CSR[1]
-  wB2CDoneMask := WireInit(Mux(
-    rSyncState === sTSyncingB2CPState,
-    1.U << rSyncThread,
-    0.U
-  ))
 
-  // Listen to the pipeline write request and update register inside
-  uTransplantBRAM.iWriteRequest.bits.registerIndex := cpu2trans.rfile_wr.addr
-  uTransplantBRAM.iWriteRequest.bits.threadID := cpu2trans.rfile_wr.tag
-  uTransplantBRAM.iWriteRequest.bits.value := cpu2trans.rfile_wr.data
-  uTransplantBRAM.iWriteRequest.valid := cpu2trans.rfile_wr.en
+  if (true) { // TODO Conditional assertions
+    when(rSyncState === sTSyncingB2CXReg) {
+      assert(uTransplantBRAM.ports.rd.xreg.req.ready, "BRAM must be ready to receive transactions when interacting with it: pushing XRegs")
+    }
+    when(rSyncState === sTSyncingB2CPState) {
+      assert(uTransplantBRAM.ports.rd.pstate.req.ready, "BRAM must be ready to receive transactions when interacting with it: pushing PState")
+    }
+    when(rSyncState ===sTSyncingC2BPState) {
+      assert(uTransplantBRAM.ports.wr.pstate.req.ready, "BRAM must be ready to receive transactions when interacting with it: pulling PState")
+    }
+  }
 }
 
 

--- a/Devteroflex/src/armflex/Transplant.scala
+++ b/Devteroflex/src/armflex/Transplant.scala
@@ -6,11 +6,10 @@ import chisel3.util._
 import arm.PROCESSOR_TYPES._
 
 import armflex.util._
+import armflex.PStateConsts._
 
 import antmicro.Bus.AXI4
-import antmicro.CSR.CSR
-import antmicro.CSR.SetCSR
-import antmicro.CSR.ClearCSR
+import antmicro.CSR._
 
 object TransplantIO extends Bundle {
   class Trans2CPU(val thidN: Int) extends Bundle { // Push state back to CPU

--- a/Devteroflex/src/armflex/TransplantBRAM.scala
+++ b/Devteroflex/src/armflex/TransplantBRAM.scala
@@ -28,6 +28,9 @@ object TransplantBRAMIO {
     val icountReg = bramBlockGetReg(block, ARCH_PSTATE_ICOUNT_OFFST % regsPerBlock)
     pstate.icount := icountReg(31, 0) // 34[31:0] -> icount
     pstate.icountBudget := icountReg(63, 32) // 34[63:32] -> icount budget
+    val asidReg = bramBlockGetReg(block, ARCH_PSTATE_ASID_OFFST % regsPerBlock)
+    pstate.asid := asidReg(31, 0)
+    pstate.asid_unused := asidReg(63, 32)
     pstate
   }
   def bramBlockPackPState(pstate: PStateRegs): UInt = {
@@ -36,6 +39,7 @@ object TransplantBRAMIO {
     block(ARCH_PSTATE_PC_OFFST % regsPerBlock) := pstate.PC
     block(ARCH_PSTATE_FLAGS_OFFST % regsPerBlock) := pstate.flags.asUInt
     block(ARCH_PSTATE_ICOUNT_OFFST % regsPerBlock) := Cat(pstate.icountBudget, pstate.icount)
+    block(ARCH_PSTATE_ASID_OFFST % regsPerBlock) := Cat(pstate.asid_unused, pstate.asid)
     return block.asUInt()
   }
 

--- a/Devteroflex/src/armflex/TransplantBRAM.scala
+++ b/Devteroflex/src/armflex/TransplantBRAM.scala
@@ -9,26 +9,98 @@ import antmicro.Bus.AXI4
 import armflex.util.BRAM
 import armflex.util.BRAMParams
 
+import armflex.PStateConsts._
+import armflex.TransplantConsts._
+import armflex.TransplantBRAMIO._
+
+object TransplantBRAMIO {
+  // Given that registers are 64-bit wide, but that 
+  // a bram block is 512-bits we align with the block granularity
+  def bramAlignAddr(thid: UInt, regIdx: UInt) = Cat(thid, regIdx >> 3)
+  def bramAlignMask(regIdx: UInt) = (0xFF.U(8.W)) << ((regIdx(2, 0)) * 8.U)
+  def bramAlignData(regIdx: UInt, data: UInt) = data << ((regIdx(2, 0) * 64.U))
+
+  def bramBlockGetReg(block: UInt, regIdx: Int): UInt = block((regIdx + 1)*64 - 1, regIdx*64)
+  def bramBlockUnpackPState(block: UInt): PStateRegs = {
+    val pstate = Wire(new PStateRegs)
+    pstate.PC := bramBlockGetReg(block, ARCH_PSTATE_PC_OFFST % regsPerBlock)
+    pstate.flags := bramBlockGetReg(block, ARCH_PSTATE_FLAGS_OFFST % regsPerBlock).asTypeOf(new PStateFlags)
+    val icountReg = bramBlockGetReg(block, ARCH_PSTATE_ICOUNT_OFFST % regsPerBlock)
+    pstate.icount := icountReg(31, 0) // 34[31:0] -> icount
+    pstate.icountBudget := icountReg(63, 32) // 34[63:32] -> icount budget
+    pstate
+  }
+  def bramBlockPackPState(pstate: PStateRegs): UInt = {
+    val block = Wire(Vec(regsPerBlock, DATA_T))
+    block := DontCare
+    block(ARCH_PSTATE_PC_OFFST % regsPerBlock) := pstate.PC
+    block(ARCH_PSTATE_FLAGS_OFFST % regsPerBlock) := pstate.flags.asUInt
+    block(ARCH_PSTATE_ICOUNT_OFFST % regsPerBlock) := Cat(pstate.icountBudget, pstate.icount)
+    return block.asUInt()
+  }
+
+  class RdPort(thidN: Int) extends Bundle {
+    val thid = Input(UInt(log2Ceil(thidN).W))
+    val xreg = new Bundle {
+      val req = Flipped(Decoupled(new RdReq))
+      val resp = Output(DATA_T)
+    }
+    val pstate = new Bundle {
+      val req = Flipped(Decoupled())
+      val resp = Output(new PStateRegs)
+    }
+  }
+
+  class RdReq extends Bundle {
+    val regIdx = UInt(log2Ceil(TRANS_STATE_THID_MAX_REGS).W)
+  }
+
+  class WrPort(thidN: Int) extends Bundle {
+    val thid = Input(UInt(log2Ceil(thidN).W))
+    val xreg = new Bundle {
+      val req = Flipped(Decoupled(new WrReq))
+    }
+    val pstate = new Bundle {
+      val req = Flipped(Decoupled(new WrPStateReq))
+    }
+  }
+
+  class WrReq extends Bundle {
+    val regIdx = UInt(log2Ceil(TRANS_STATE_THID_MAX_REGS).W)
+    val data = DATA_T
+  }
+
+  class TransBRAM2CpuIO(thidN: Int) extends Bundle {
+    val rd = new RdPort(thidN)
+    val wr = new WrPort(thidN)
+  }
+
+  // Use the 2nd BRAM ports to sync data with the CPU.
+  // This port is for submitting the pstate. It has the highest priority.
+  class WrPStateReq extends Bundle {
+    val state = new PStateRegs()
+  }
+
+}
 
 // This registers store the ArchState that should be sent to the host and update by the host.
 // - Each thread has 32 64bit registers, and PC, the flag, and the stack pointer.
 // - We allocate 512 byte (64*64bit) space for each thread. The first 256 bytes are for the x0 - x31 registers, and then one 64byte for PC + Flag + Stack, and the following position are preserved for future reuse.
 // - At present we support at most 128 threads, so 16bit address at most. (Not sure if we have such a large space from the shell.)
 
-class TransplantBRAM(
-  threadNumber: Int
-) extends Module {
-  assert(threadNumber <= 128)
+class TransplantBRAM(thidN: Int) extends Module {
+  assert(thidN <= 128)
   assert(DATA_SZ == 64)
   assert(REG_N == 32)
 
-  val S_AXI = IO(Flipped(new AXI4(16, 512)))
+  val S_AXI = IO(Flipped(new AXI4(16, BLOCK_SZ)))
   val sAXIIdle :: sAXIReading :: sAXIReadWaitComplete :: sAXIWriting :: sAXIWriteResponse :: Nil = Enum(5)
 
-  val uBRAM = Module(new BRAM()(new BRAMParams(
-    64, 8, 1024, "", false
-  )))
+  val uBRAM = Module(new BRAM()(new BRAMParams(64, 8, 1024, "", false)))
 
+
+  // ---------------------- AXI -------------------------
+ 
   // Two AXI transactions use the same BRAM ports, and cannot happen at the same time.
   // the AXI contexts.
   val rAXIState = RegInit(sAXIIdle)
@@ -44,6 +116,10 @@ class TransplantBRAM(
   }
 
   val wAXIReadSync = Wire(Decoupled(new axi_read_meta_info_t))
+  wAXIReadSync.bits.isLast := false.B
+
+  val startB2C = WireInit(false.B)
+  val doneB2H = WireInit(false.B) // B2H: BRAM to HOST read
 
   switch(rAXIState){
     is(sAXIIdle){
@@ -70,16 +146,10 @@ class TransplantBRAM(
       when(wAXIReadSync.fire){
         rAXIAddr := rAXIAddr + (1.U << (rAXIAddrStep))
         rAXICounter := rAXICounter + 1.U
-        rAXIState := Mux(
-          rAXICounter === rAXICounterEnd,
-          sAXIReadWaitComplete,
-          sAXIReading
-        )
-      }
-    }
-    is(sAXIReadWaitComplete){ // wait for the last read transactions to be complete
-      when(S_AXI.r.fire){
-        rAXIState := sAXIIdle
+        when(rAXICounter === rAXICounterEnd) {
+          wAXIReadSync.bits.isLast := true.B
+          rAXIState := sAXIReadWaitComplete
+        }
       }
     }
     is(sAXIWriting){
@@ -87,13 +157,19 @@ class TransplantBRAM(
         rAXIAddr := rAXIAddr + (1.U << (rAXIAddrStep))
         rAXICounter := rAXICounter + 1.U
         when(rAXICounter === rAXICounterEnd){
-          assert(S_AXI.w.wlast)
           rAXIState := sAXIWriteResponse
         }
       }
     }
+    is(sAXIReadWaitComplete){ // wait for the last read transactions to be complete
+      when(S_AXI.r.fire){
+        doneB2H := true.B
+        rAXIState := sAXIIdle
+      }
+    }
     is(sAXIWriteResponse){
       when(S_AXI.b.fire){
+        startB2C := true.B
         rAXIState := sAXIIdle
       }
     }
@@ -115,7 +191,6 @@ class TransplantBRAM(
 
   // BRAM sync
   // wAXIReadSync.bits.id := rAXIID
-  wAXIReadSync.bits.isLast := rAXICounter === rAXICounterEnd
   wAXIReadSync.valid := rAXIState === sAXIReading
 
   // Sync data is valid together with the read output from the BRAM.
@@ -128,7 +203,6 @@ class TransplantBRAM(
   S_AXI.r.rlast := wAXIReadSyncOut.bits.isLast
   S_AXI.r.rresp := 0.U
   S_AXI.r.rvalid := wAXIReadSyncOut.valid
-
   wAXIReadSyncOut.ready := S_AXI.r.rready
 
   S_AXI.aw.awready := rAXIState === sAXIIdle && !S_AXI.ar.arvalid // write has lower priority.
@@ -139,96 +213,66 @@ class TransplantBRAM(
   S_AXI.b.bresp := 0.U
   S_AXI.b.bvalid := rAXIState === sAXIWriteResponse
 
-  // Use the 2nd BRAM ports to sync data with the CPU.
-  // This port is for submitting the pstate. It has the highest priority.
-  class TransplantBRAMPStateSubmitRequest extends Bundle {
-    val threadID = UInt(log2Ceil(threadNumber).W)
-    val state = new PStateRegs()
 
-    def bramAddr = Cat(threadID, 4.U) // Cat(threadID, 0b100.U)
+  // ---------------------- CPU -------------------------
+  val ports = IO(new TransBRAM2CpuIO(thidN))
+  val rdPort = ports.rd
+  val wrPort = ports.wr
 
-    // TODO: We actually change the software interface! Be careful!
-    // 32 -> PC, 33 -> FLGAS, 34 -> ICount
-    def writeData: UInt = {
-      val res = Wire(Vec(64, UInt(64.W)))
-      res(0) := state.PC
-      res(1) := state.flags.asUInt
-      res(2) := Cat(state.icountBudget, state.icount)
-      for (i <- 3 until 64){
-        res(i) := DontCare
-      }
-
-      return res.asUInt()
-    }
-
-    def writeMask = Cat(0xFFFF.U(16.W), 0xFFFF.U(16.W))
-  }
-
-  val iPstateWriteRequest = IO(Flipped(Decoupled(new TransplantBRAMPStateSubmitRequest)))
-  iPstateWriteRequest.ready := true.B
-
-  class TransplantBRAMReadRequest extends Bundle {
-    val threadID = UInt(log2Ceil(threadNumber).W)
-    val registerIndex = UInt(6.W)
-
-    def bramAddr = Cat(threadID, registerIndex >> 3)
-  }
-
-  // Register read port. It has the 2nd prioryty.
-  val iReadRequest = IO(Flipped(Decoupled(new TransplantBRAMReadRequest)))
-  iReadRequest.ready := iPstateWriteRequest.ready && !iPstateWriteRequest.valid
-
-  val rReadBias = RegEnable(iReadRequest.bits.registerIndex(2, 0), iReadRequest.fire)
-  val oReadReply = IO(Output(UInt(64.W)))
-
-  val iReadPStateRequest = IO(Flipped(Decoupled(UInt(6.W))))
-  iReadPStateRequest.ready := iReadRequest.ready && !iReadRequest.valid
-
-  val oReadPStateReply = IO(Output(new PStateRegs))
-
-  class TransplantBRAMWriteRequest extends Bundle {
-    val threadID = UInt(log2Ceil(threadNumber).W)
-    val registerIndex = UInt(6.W) // up to 64 64bit place is available.
-
-    def bramAddr = Cat(threadID, registerIndex >> 3)
-    def bramMask = (0xFF.U(8.W)) << ((registerIndex(2, 0)) * 8.U)
-
-    val value = UInt(64.W)
-
-    def bramWriteData = value << ((registerIndex(2, 0) * 64.U))
-  }
-
+  // Register read port. It has the 2nd priority.
+  val rRdBias = RegEnable(rdPort.xreg.req.bits.regIdx(2, 0), rdPort.xreg.req.fire)
+  rdPort.xreg.req.ready := ports.wr.pstate.req.ready && !ports.wr.pstate.req.valid
+  rdPort.pstate.req.ready := rdPort.xreg.req.ready && !rdPort.xreg.req.valid
   // This port is for the normal register writing.
-  val iWriteRequest = IO(Flipped(Decoupled(new TransplantBRAMWriteRequest)))
-  iWriteRequest.ready := iReadPStateRequest.ready && !iReadPStateRequest.valid
+  wrPort.xreg.req.ready := rdPort.pstate.req.ready && !rdPort.pstate.req.valid
+  wrPort.pstate.req.ready := true.B
+ 
+  rdPort.xreg.resp := uBRAM.portB.DO >> (rRdBias * 64.U)
+  rdPort.pstate.resp := bramBlockUnpackPState(uBRAM.portB.DO)
 
   // determine the BRAM address
-  when(iWriteRequest.valid){
-    uBRAM.portB.ADDR := iWriteRequest.bits.bramAddr
-    uBRAM.portB.DI := iWriteRequest.bits.bramWriteData
-    uBRAM.portB.WE := iWriteRequest.bits.bramMask
-  }.elsewhen(iPstateWriteRequest.fire){
-    uBRAM.portB.ADDR := iPstateWriteRequest.bits.bramAddr
-    uBRAM.portB.DI := iPstateWriteRequest.bits.writeData
-    uBRAM.portB.WE := iPstateWriteRequest.bits.writeMask
-  }.elsewhen(iReadRequest.fire){
-    uBRAM.portB.ADDR := iReadRequest.bits.bramAddr
+  when(wrPort.xreg.req.fire){
+    val xregIdx = wrPort.xreg.req.bits.regIdx
+    uBRAM.portB.ADDR := bramAlignAddr(wrPort.thid, xregIdx)
+    uBRAM.portB.DI   := bramAlignData(xregIdx, wrPort.xreg.req.bits.data)
+    uBRAM.portB.WE   := bramAlignMask(xregIdx)
+  }.elsewhen(wrPort.pstate.req.fire){
+    uBRAM.portB.ADDR := bramAlignAddr(wrPort.thid, TRANS_STATE_PState_OFFST.U)
+    uBRAM.portB.DI := bramBlockPackPState(wrPort.pstate.req.bits.state)
+    uBRAM.portB.WE := Fill(32, 1.U) // Write Half Block
+  }.elsewhen(rdPort.xreg.req.fire){
+    uBRAM.portB.ADDR := bramAlignAddr(rdPort.thid, rdPort.xreg.req.bits.regIdx)
+    uBRAM.portB.DI := DontCare
+    uBRAM.portB.WE := 0.U
+  }.elsewhen(rdPort.pstate.req.fire) {
+    uBRAM.portB.ADDR := bramAlignAddr(wrPort.thid, TRANS_STATE_PState_OFFST.U)
     uBRAM.portB.DI := DontCare
     uBRAM.portB.WE := 0.U
   }.otherwise {
-    uBRAM.portB.ADDR := Cat(iReadPStateRequest.bits, 4.U) // Cat(threadID, 0b100.U)
+    uBRAM.portB.ADDR := DontCare
     uBRAM.portB.DI := DontCare
     uBRAM.portB.WE := 0.U
   }
 
   uBRAM.portB.EN := true.B
 
-  oReadReply := uBRAM.portB.DO >> (rReadBias * 64.U)
-  // Fixed position.
-  oReadPStateReply.PC := uBRAM.portB.DO(63, 0) // 32 -> PC
-  oReadPStateReply.flags := uBRAM.portB.DO(127, 64).asTypeOf(new PStateFlags) // 33 -> Flags
-  oReadPStateReply.icount := uBRAM.portB.DO(159, 128) // 34[31:0] -> icount
-  oReadPStateReply.icountBudget := uBRAM.portB.DO(191, 160) // 34[63:32] -> icount budget
+  if (true) { // TODO Conditional asserts
+    when(rAXIState === sAXIReadWaitComplete && S_AXI.r.fire) {
+      assert(S_AXI.r.rlast, "Transplant:RD: rlast flag must be raised on last block")
+    }
+    when(rAXIState === sAXIWriting && rAXICounter === rAXICounterEnd && S_AXI.w.fire) {
+      assert(S_AXI.w.wlast, "Transplant:WR: wlast flag must be raised on last block")
+    }
+    when(rAXIState === sAXIIdle) {
+      when(S_AXI.ar.fire) {
+        assert(S_AXI.ar.arburst === 1.U, "Transplant:RD: arburst must be one")
+      }.elsewhen(S_AXI.aw.fire){
+        assert(S_AXI.aw.awburst === 1.U, "Transplant:WR: awburst must be one")
+      }
+    }
+    assert((wrPort.xreg.req.fire.asUInt + wrPort.pstate.req.fire.asUInt +
+           rdPort.xreg.req.fire.asUInt + rdPort.pstate.req.fire.asUInt) <= 1.U, "Can fire at most 1 request at the same time")
+  }
 }
 
 object TransplantBRAMVerilogEmitter extends App {

--- a/Devteroflex/src/util/BaseModules.scala
+++ b/Devteroflex/src/util/BaseModules.scala
@@ -68,6 +68,32 @@ object ExtraUtils {
 
 }
 
+
+/* If both set and clear are risen, it clears the register
+ */
+class SetClearReg(val width: Int) extends Module {
+  val io = IO(new Bundle {
+    val set = Input(UInt(width.W))
+    val clear = Input(UInt(width.W))
+    val value = Output(UInt(width.W))
+  })
+  val reg = RegInit(0.U(width.W))
+  reg := (reg | io.set) & (~io.clear)
+  io.value := reg
+}
+
+object SetClearReg {
+  def apply(width: Int) = {
+    val set = WireInit(0.U(width.W))
+    val clear = WireInit(0.U(width.W))
+    val reg = Module(new SetClearReg(width))
+    reg.io.set := set
+    reg.io.clear := clear
+    
+    (reg.io.value, set, clear)
+  }
+}
+
 /** An I/O Bundle for FlushReg (FlushRegister)
   * @params gen The type of data of the Reg
   */

--- a/Devteroflex/test/src/armflex/GeneralDrivers.scala
+++ b/Devteroflex/test/src/armflex/GeneralDrivers.scala
@@ -1,0 +1,47 @@
+package armflex
+
+import chisel3._
+import chisel3.experimental._
+import chisel3.experimental.BundleLiterals._
+
+import org.scalatest.freespec.AnyFreeSpec
+import chiseltest._
+import chiseltest.internal._
+
+object ArmflexStructsLits {
+    object PStateRegs {
+        def makeLit(): PStateRegs = makeLit(0.U, 0.U, 0.U)
+        def makeLit(pc: UInt, asid: UInt, execMode: UInt): PStateRegs = new PStateRegs().Lit(
+            _.PC -> pc,
+            _.asid -> asid,
+            _.asid_unused -> 0.U,
+            _.flags -> new PStateFlags().Lit(
+                _.NZCV -> 0.U,
+                _.execMode -> execMode,
+                _.isException -> false.B,
+                _.isICountDepleted -> false.B,
+                _.isUndef -> false.B
+            ),
+            _.icount -> 0.U,
+            _.icountBudget -> 0.U
+        )
+    }
+}
+
+object GeneralDrivers{
+    implicit class RFileIOWrPortDriver(target: RFileIO.WRPort)(implicit clock: Clock) {
+        def init() = {
+            target.addr.poke(0.U)
+            target.data.poke(0.U)
+            target.tag.poke(0.U)
+            target.en.poke(false.B)
+        }
+
+        def wr(reg: UInt, data: UInt) = timescope {
+            target.addr.poke(reg)
+            target.data.poke(data)
+            target.en.poke(true.B)
+            clock.step()
+        }
+    }
+}

--- a/Devteroflex/test/src/armflex/TransplantUnitTest.scala
+++ b/Devteroflex/test/src/armflex/TransplantUnitTest.scala
@@ -67,7 +67,7 @@ class Cpu2TransUnitTest extends AnyFreeSpec with ChiselScalatestTester {
   }
     "Send start without state available" in {
     test(new Cpu2TransBramUnitTestDriver(32)).withAnnotations(Seq(
-      VerilatorBackendAnnotation, TargetDirAnnotation("test/transplant/Cpu2TransTest/Wait"), 
+      VerilatorBackendAnnotation, TargetDirAnnotation("test/transplant/Cpu2TransTest/WaitNotEnabled"), 
       WriteVcdAnnotation)) {
         dut => 
           dut.init()
@@ -173,7 +173,11 @@ object TransplantUnitDrivers {
       target.transBram2Cpu.rd.pstate.req.ready.poke(true.B)
       target.transBram2Cpu.rd.pstate.req.valid.expect(true.B)
       clock.step()
+      target.trans2cpu.thid.expect(thid)
       target.trans2cpu.pstate.valid.expect(true.B)
+      clock.step()
+      target.trans2cpu.thid.expect(thid)
+      // Done state now
     }
 
     def startTransBram2Cpu(thid: Int, xregs: Seq[BigInt], pstate: PStateRegs) = {
@@ -181,7 +185,7 @@ object TransplantUnitDrivers {
       prepareTransResp(thid, xregs, pstate)
       setTrans2CpuStart(thid)
       expectTrans2CpuState(thid, xregs, pstate)
-      target.trans2cpu.start.bits.expect(thid.U)
+      target.trans2cpu.thid.expect(thid.U)
       if (pstate.flags.execMode.litValue == PSTATE_FLAGS_EXECUTE_WAIT) {
         clock.step()
         assert(target.S_CSR.readReg(TRANS_REG_OFFST_WAITING) == 1 << thid)

--- a/Devteroflex/test/src/armflex/TransplantUnitTest.scala
+++ b/Devteroflex/test/src/armflex/TransplantUnitTest.scala
@@ -1,0 +1,207 @@
+package armflex
+
+import chisel3._
+import chisel3.experimental._
+import chisel3.experimental.BundleLiterals._
+
+import org.scalatest.freespec.AnyFreeSpec
+import chiseltest._
+import chiseltest.internal._
+
+import firrtl.options.TargetDirAnnotation
+
+import chisel3.util.{Queue}
+import armflex.PStateConsts._
+import armflex.TransplantConsts._
+import armflex.ArmflexStructsLits._
+import antmicro.util.CSRDrivers.CSRBusBundleDriver
+import armflex.util.SoftwareStructs
+import armflex.GeneralDrivers._
+
+import armflex.TransplantUnitDrivers.{
+  TransBRAM2CpuIODrivers, CPU2TransDriver, Cpu2TransBramUnitTest
+}
+
+
+class Cpu2TransUnitTest extends AnyFreeSpec with ChiselScalatestTester {
+  "Start transplant with normal execution" in {
+    test(new Cpu2TransBramUnitTestDriver(32)).withAnnotations(Seq(
+      VerilatorBackendAnnotation, TargetDirAnnotation("test/transplant/Cpu2TransTest"), 
+      WriteVcdAnnotation)) {
+        
+        dut => 
+          val xregs = for(reg <- 0 until 32) yield BigInt(reg * 15)
+          val pstate = new PStateRegs().Lit(
+            _.PC -> 0x100.U, _.asid -> 0x10.U, _.asid_unused -> 0.U,
+            _.flags -> new PStateFlags().Lit(
+              _.NZCV -> 3.U, _.isException -> false.B, _.isICountDepleted -> false.B,
+              _.isUndef -> false.B, _.execMode -> PSTATE_FLAGS_EXECUTE_NORMAL.U),
+            _.icount -> 0.U, _.icountBudget -> 0.U
+          )
+          dut.init()
+          dut.startTransBram2Cpu(4, xregs, pstate)
+    }
+  }
+}
+
+object TransplantUnitDrivers {
+  implicit class CPU2TransDriver(target: TransplantIO.CPU2Trans)(implicit clock: Clock) {
+    def init() = {
+      target.doneCPU.valid.poke(false.B)
+      target.doneCPU.tag.poke(0.U)
+      target.rfile_wr.init()
+      target.pstate.poke(ArmflexStructsLits.PStateRegs.makeLit())
+    }
+    def sendCpu2Trans(thid: Int): Unit = {
+      target.doneCPU.valid.poke(true.B)
+      target.doneCPU.tag.poke(thid.U)
+      clock.step()
+    }
+  }
+
+  implicit class Trans2CpuDriver(target: TransplantIO.Trans2CPU)(implicit clock: Clock) {
+    def init() = {
+    }
+  }
+ 
+
+  implicit class TransBRAM2CpuIODrivers(target: TransBram2HostUnitIO.TransBRAM2CpuIO)(implicit clock: Clock) {
+    def wr(thid: Int, xregs: Seq[BigInt]): Unit = {
+      assert(xregs.size == 32)
+      target.wr.thid.poke((1 << thid).U)
+      for(reg <- 0 until xregs.size) {
+        target.wr.xreg.req.enqueue(new TransBram2HostUnitIO.WrReq().Lit(
+          _.regIdx -> reg.U, _.data -> xregs(reg).U))
+      }
+    }
+  }
+
+  implicit class Cpu2TransBramUnitTest(target: Cpu2TransBramUnitTestDriver) {
+    implicit val clock: Clock = target.clock
+    def init() = {
+      target.S_CSR.init()
+      target.cpu2trans.init()
+      target.pstateRdRespValidate.initSink()
+      target.pstateRdRespValidate.setSinkClock(clock)
+      target.xregsRdRespValidate.initSink()
+      target.xregsRdRespValidate.setSinkClock(clock)
+      target.trans2cpu.init()
+      target.enqXRegsRespQ.initSource()
+      target.enqXRegsRespQ.setSourceClock(clock)
+      target.enqPStateRespQ.initSource()
+      target.enqPStateRespQ.setSourceClock(clock)
+      target.transBram2Cpu.rd.xreg.req.initSink()
+      target.transBram2Cpu.rd.pstate.req.initSink()
+      target.transBram2Cpu.wr.xreg.req.initSink()
+      target.transBram2Cpu.wr.pstate.req.initSink()
+      target.transBram2Cpu.rd.xreg.req.setSourceClock(clock)
+      target.transBram2Cpu.rd.pstate.req.setSourceClock(clock)
+      target.transBram2Cpu.wr.xreg.req.setSourceClock(clock)
+      target.transBram2Cpu.wr.pstate.req.setSourceClock(clock)
+    }
+    def setTrans2CpuStart(thid: Int) = timescope { target.transBram2Cpu.ctrl.setTrans2Cpu.poke((1 << thid).U); clock.step() }
+    def clearTrans2CpuPending(thid: Int) = timescope { target.transBram2Cpu.ctrl.clearTrans2Host.poke((1 << thid).U); clock.step() }
+
+    def hasRecvForceTrans(): Boolean = target.cpu2trans.forceTransplant.peek().litValue != 0
+    def hasRecvSetStopCpu(): Boolean = target.cpu2trans.stopCPU.peek().litValue != 0
+    def hasStallCpu2Trans(): Boolean = target.cpu2trans.stallPipeline.litToBoolean
+    def hasStallTrans2Cpu(): Boolean = target.trans2cpu.stallPipeline.litToBoolean
+
+    def pipeSendStateExpect(thid: Int, xregs: Seq[BigInt], pstate: PStateRegs): Unit = {
+      assert(!target.cpu2trans.stallPipeline.litToBoolean)
+      target.cpu2trans.pstate.poke(pstate)
+      target.cpu2trans.rfile_wr.tag.poke(thid.U)
+      for(reg <- 0 until xregs.size) {
+        target.transBram2Cpu.wr.xreg.req.expectDequeue(new TransBram2HostUnitIO.WrReq().Lit(
+          _.regIdx -> reg.U,
+          _.data -> xregs(reg).U
+        ))
+      }
+      for(reg <- 0 until xregs.size) {
+        target.cpu2trans.rfile_wr.wr(reg.U, xregs(reg).U)
+        clock.step()
+      }
+    }
+    def prepareTransResp(thid: Int, xregs: Seq[BigInt], pstate: PStateRegs) = {
+      target.xregsRdRespValidate.ready.poke(true.B)
+      target.pstateRdRespValidate.ready.poke(true.B)
+      for(reg <- 0 until xregs.size) {
+        target.xregsRdRespValidate.expectDequeue(xregs(reg).U)
+        target.enqXRegsRespQ.enqueueNow(xregs(reg).U)
+      }
+      target.enqPStateRespQ.enqueueNow(pstate)
+      target.pstateRdRespValidate.expectDequeue(pstate)
+    }
+ 
+    def expectTrans2CpuState(thid: Int, xregs: Seq[BigInt], pstate: PStateRegs) = {
+      target.transBram2Cpu.rd.xreg.req.ready.poke(true.B)
+      target.transBram2Cpu.rd.pstate.req.ready.poke(true.B)
+      for(reg <- 0 until xregs.size) {
+        target.transBram2Cpu.rd.xreg.req.enqueueNow(
+          new TransBram2HostUnitIO.RdReq().Lit(_.regIdx -> reg.U)
+        )
+      }
+      target.transBram2Cpu.rd.pstate.req.enqueueNow(0.U)
+      target.trans2cpu.pstate.valid.expect(true.B)
+    }
+
+    def startTransBram2Cpu(thid: Int, xregs: Seq[BigInt], pstate: PStateRegs) = {
+      prepareTransResp(thid, xregs, pstate)
+      setTrans2CpuStart(thid)
+      expectTrans2CpuState(thid, xregs, pstate)
+      target.trans2cpu.thread.expect(thid.U)
+      if (pstate.flags.execMode.litValue == PSTATE_FLAGS_EXECUTE_WAIT) {
+        clock.step()
+        assert(target.S_CSR.readReg(TRANS_REG_OFFST_WAITING) == 1 << thid)
+      } else if (pstate.flags.execMode.litValue == PSTATE_FLAGS_EXECUTE_NORMAL) {
+        target.trans2cpu.start.expect(1.U << thid)
+      } else if (pstate.flags.execMode.litValue == PSTATE_FLAGS_EXECUTE_SINGLESTEP) {
+        target.trans2cpu.start.expect(1.U << thid)
+        clock.step()
+        assert(target.S_CSR.readReg(TRANS_REG_OFFST_STOP_CPU) == 1 << thid)
+      }
+    }
+  }
+}
+    
+class Cpu2TransBramUnitTestDriver(thidN: Int) extends Module {
+  val dut = Module(new Cpu2TransBramUnit(thidN))
+  val cpu2trans = IO(dut.cpu2trans.cloneType)
+  val trans2cpu = IO(dut.trans2cpu.cloneType)
+  val transBram2Cpu = IO(Flipped(dut.transBram2Cpu.cloneType))
+  val S_CSR = IO(Flipped(dut.S_CSR.cloneType))
+  cpu2trans <> dut.cpu2trans
+  trans2cpu <> dut.trans2cpu
+  transBram2Cpu <> dut.transBram2Cpu
+  S_CSR <> dut.S_CSR
+
+  // Buffer resp for testbench
+  val xregsRespQ = Module(new Queue(transBram2Cpu.rd.xreg.resp.cloneType, 512, true, true))
+  val xregsRdRespValidate = IO(xregsRespQ.io.deq.cloneType)
+  val enqXRegsRespQ = IO(Flipped(xregsRespQ.io.enq.cloneType))
+  xregsRespQ.io.enq <> enqXRegsRespQ
+  xregsRespQ.io.deq.ready := RegNext(transBram2Cpu.rd.xreg.req.fire)
+
+  xregsRdRespValidate.valid := xregsRespQ.io.deq.fire
+  xregsRdRespValidate.bits := trans2cpu.rfile_wr.data
+  dut.transBram2Cpu.rd.xreg.resp := xregsRespQ.io.deq.bits
+  when(xregsRdRespValidate.valid) { 
+    assert(trans2cpu.rfile_wr.en)
+    assert(trans2cpu.rfile_wr.addr === RegNext(transBram2Cpu.rd.xreg.req.bits.regIdx))
+    assert(trans2cpu.rfile_wr.tag === RegNext(transBram2Cpu.rd.thid))
+    assert(trans2cpu.stallPipeline)
+    assert(trans2cpu.busyTrans2Cpu)
+  }
+
+  val pstateRespQ = Module(new Queue(transBram2Cpu.rd.pstate.resp.cloneType, 8, true, true))
+  val pstateRdRespValidate = IO(pstateRespQ.io.deq.cloneType)
+  val enqPStateRespQ = IO(Flipped(pstateRespQ.io.enq.cloneType))
+  pstateRespQ.io.enq <> enqPStateRespQ
+  pstateRespQ.io.deq.ready := RegNext(transBram2Cpu.rd.pstate.req.fire)
+  pstateRdRespValidate.valid := RegNext(pstateRespQ.io.deq.fire)
+  pstateRdRespValidate.bits := trans2cpu.pstate.bits
+  dut.transBram2Cpu.rd.pstate.resp := pstateRespQ.io.deq.bits
+  when(xregsRdRespValidate.valid) {
+    assert(trans2cpu.pstate.valid)
+  }
+}

--- a/Devteroflex/test/src/util/CSRDrivers.scala
+++ b/Devteroflex/test/src/util/CSRDrivers.scala
@@ -16,15 +16,19 @@ object CSRDrivers {
       target.write.poke(false.B)
     }
     def readReg(addr: BigInt): BigInt = {
-      target.addr.poke(addr.U)
-      target.dataOut.poke(0.U)
-      target.read.poke(true.B)
-      target.write.poke(false.B)
-      clock.step()
-      target.dataIn.peek().litValue
+      var resp: BigInt = 0
+      timescope {
+        target.addr.poke(addr.U)
+        target.dataOut.poke(0.U)
+        target.read.poke(true.B)
+        target.write.poke(false.B)
+        clock.step()
+        resp = target.dataIn.peek().litValue
+      }
+      resp
     }
 
-    def writeReg(addr: BigInt, value: BigInt): Unit = {
+    def writeReg(addr: BigInt, value: BigInt): Unit = timescope {
       target.addr.poke(addr.U)
       target.dataOut.poke(value.U)
       target.read.poke(false.B)

--- a/Devteroflex/test/src/util/CSRDrivers.scala
+++ b/Devteroflex/test/src/util/CSRDrivers.scala
@@ -1,0 +1,35 @@
+package antmicro.util
+
+import chisel3._
+import chisel3.experimental._
+import chisel3.util._
+import chiseltest._
+
+import antmicro.CSR.CSRBusBundle
+
+object CSRDrivers {
+  implicit class CSRBusBundleDriver(target: CSRBusBundle)(implicit clock: Clock) {
+    def init() = {
+      target.addr.poke(0.U)
+      target.dataOut.poke(0.U)
+      target.read.poke(false.B)
+      target.write.poke(false.B)
+    }
+    def readReg(addr: BigInt): BigInt = {
+      target.addr.poke(addr.U)
+      target.dataOut.poke(0.U)
+      target.read.poke(true.B)
+      target.write.poke(false.B)
+      clock.step()
+      target.dataIn.peek().litValue
+    }
+
+    def writeReg(addr: BigInt, value: BigInt): Unit = {
+      target.addr.poke(addr.U)
+      target.dataOut.poke(value.U)
+      target.read.poke(false.B)
+      target.write.poke(true.B)
+      clock.step()
+    }
+  }
+}

--- a/regression/src/client/fpga_interface.c
+++ b/regression/src/client/fpga_interface.c
@@ -24,6 +24,11 @@
  * 
  * @note this function will not start the transplant but only bind.
  */
+static int transplantPushState(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
+  assert(thid < 128 && "The maximum number of supported thread is 128.");
+  return writeAXI(c, BASE_ADDR_TRANSPLANT_DATA + thid * TRANS_STATE_THID_MAX_BYTES, state, TRANS_STATE_SIZE_BYTES);
+}
+
 int transplantPushAndWait(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
   FLAGS_SET_EXEC_MODE(state->flags, PSTATE_FLAGS_EXECUTE_WAIT);
   int res = transplantPushState(c, thid, state);
@@ -47,10 +52,7 @@ int transplantGetState(const FPGAContext *c, uint32_t thid, DevteroflexArchState
   return readAXI(c, BASE_ADDR_TRANSPLANT_DATA + thid * TRANS_STATE_THID_MAX_BYTES, state, TRANS_STATE_SIZE_BYTES);
 }
 
-int transplantPushState(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
-  assert(thid < 128 && "The maximum number of supported thread is 128.");
-  return writeAXI(c, BASE_ADDR_TRANSPLANT_DATA + thid * TRANS_STATE_THID_MAX_BYTES, state, TRANS_STATE_SIZE_BYTES);
-}
+
 
 int transplantWaitTillPending(const FPGAContext *c, uint32_t *pending_threads) {
   uint32_t pending = 0;

--- a/regression/src/client/fpga_interface.c
+++ b/regression/src/client/fpga_interface.c
@@ -78,12 +78,12 @@ int transplantSinglestep(const FPGAContext *c, uint32_t thid, uint32_t asid, Dev
 
 int transplantGetState(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
   assert(thid < 128 && "The maximum number of supported thread is 128.");
-  return readAXI(c, BASE_ADDR_TRANSPLANT_DATA + thid * 512, state, 320);
+  return readAXI(c, BASE_ADDR_TRANSPLANT_DATA + thid * TRANS_STATE_THID_MAX_BYTES, state, TRANS_STATE_SIZE_BYTES);
 }
 
 int transplantPushState(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
   assert(thid < 128 && "The maximum number of supported thread is 128.");
-  return writeAXI(c, BASE_ADDR_TRANSPLANT_DATA + thid * 512, state, 320);
+  return writeAXI(c, BASE_ADDR_TRANSPLANT_DATA + thid * TRANS_STATE_THID_MAX_BYTES, state, TRANS_STATE_SIZE_BYTES);
 }
 
 int transplantWaitTillPending(const FPGAContext *c, uint32_t *pending_threads) {

--- a/regression/src/client/fpga_interface.c
+++ b/regression/src/client/fpga_interface.c
@@ -14,20 +14,6 @@
  */
 
 /**
- * Bind a thread id with process id.
- * @param thid the given thread id.
- * @param asid the process id. 
- * @returns 0 if successful.
- *
- * @note associate with S_AXIL_TT
- * @note pairing a thread id with 0 asid means translanting back since no asid in a system will be zero.
- */
-int mmuRegisterTHID2ASID(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
-  assert(thid < 128 && "The maximum number of supported thread is 128.");
-  return writeAXIL(c, BASE_ADDR_BIND_ASID_THID + thid * 4, state->asid);
-}
-
-/**
  * Push the context of specific thread to the FPGA.
  * 
  * @param thid the thread if that this thread will be bind to.
@@ -39,39 +25,20 @@ int mmuRegisterTHID2ASID(const FPGAContext *c, uint32_t thid, DevteroflexArchSta
  * @note this function will not start the transplant but only bind.
  */
 int transplantPushAndWait(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
-  // 1. register thread id.
-  int res = mmuRegisterTHID2ASID(c, thid, state->asid);
-  if(res != 0) return res;
-  // 2. push the state.
-  res = transplantPushState(c, thid, state);
+  FLAGS_SET_EXEC_MODE(state->flags, PSTATE_FLAGS_EXECUTE_WAIT);
+  int res = transplantPushState(c, thid, state);
   return res;
 }
 
-/**
- * Transplant a thread back from the FPGA and load its context.
- * 
- * @param thid the thread that should be transplanted.
- * @param state the state registers of the thread.
- * 
- * @returns 0 if successful.
- * 
- * @note Please make sure that target thread must be ready to be transplanted back. Unknown case will be happened if thread is still working.
- * FIXME: Add mechanism to stop the execution of that thread on FPGA
- */
-int transplantUnregisterAndPull(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
-  // 1. unregister thread id.
-  int res = mmuRegisterTHID2ASID(c, thid, 0);
-  if(res != 0) return res;
-  // 2. Read staste.
-  res = transplantGetState(c, thid, state);
+int transplantPushAndStart(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
+  FLAGS_SET_EXEC_MODE(state->flags, PSTATE_FLAGS_EXECUTE_NORMAL);
+  int res = transplantPushState(c, thid, state);
   return res;
 }
 
-int transplantSinglestep(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
-  int res = 0;
-  res |= transplantPushAndWait(c, thid, asid, state);
-  res |= transplantStopCPU(c, thid);
-  res |= transplantStart(c, thid);
+int transplantPushAndSinglestep(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state) {
+  FLAGS_SET_EXEC_MODE(state->flags, PSTATE_FLAGS_EXECUTE_SINGLESTEP);
+  int res = transplantPushState(c, thid, state);
   return res;
 }
 
@@ -94,7 +61,6 @@ int transplantWaitTillPending(const FPGAContext *c, uint32_t *pending_threads) {
     if(transplantPending(c, &pending)) return -1;
     usleep(1e5);
   }
-  transplantFreePending(c, pending);
   *pending_threads = pending;
 #ifndef AWS_FPGA
   printf("Pending Threads[%x]\n", pending);
@@ -107,11 +73,19 @@ int transplantPending(const FPGAContext *c, uint32_t *pending_threads) {
   return readAXIL(c, BASE_ADDR_TRANSPLANT_CTRL + TRANS_REG_OFFST_PENDING, pending_threads);
 }
 
-int transplantFreePending(const FPGAContext *c, uint32_t pending_threads) {
-  return writeAXIL(c, BASE_ADDR_TRANSPLANT_CTRL + TRANS_REG_OFFST_FREE_PENDING, pending_threads);
+int transplantFreePending(const FPGAContext *c, uint32_t free_pending_threads) {
+  // We made it such as the AXI transaction frees the Pending bit instead of the HOST
+  uint32_t pending_threads;
+  int ret = readAXIL(c, BASE_ADDR_TRANSPLANT_CTRL + TRANS_REG_OFFST_PENDING, &pending_threads);
+  assert((pending_threads & free_pending_threads) == 0);
+  return 0;
 }
 
 int transplantStart(const FPGAContext *c, uint32_t thid) {
+  uint32_t waiting_threads = 0;
+  do {
+    readAXIL(c, BASE_ADDR_TRANSPLANT_CTRL + TRANS_REG_OFFST_WAITING, &waiting_threads);
+  } while(!(waiting_threads & (1 << thid)));
   return writeAXIL(c, BASE_ADDR_TRANSPLANT_CTRL + TRANS_REG_OFFST_START, 1 << thid);
 }
 

--- a/regression/src/client/fpga_interface.h
+++ b/regression/src/client/fpga_interface.h
@@ -187,11 +187,11 @@ int dramPagePull(const FPGAContext *c, uint64_t paddr, void *page);
 #define TRANS_STATE_SIZE_BYTES      (320)   // 5 512-bit blocks; State fits in this amount of bytes
 #define TRANS_STATE_THID_MAX_BYTES  (512)   // 8 512-bit blocks; max bytes allocated per thread
 #define TRANS_STATE_THID_MAX_REGS   (512/8) // 64 64-bit words: total regs allocated per thread
-int transplantRegisterAndPush(const FPGAContext *c, uint32_t thid, uint32_t asid, DevteroflexArchState *state);
+int transplantPushAndWait(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
 int transplantUnregisterAndPull(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
 int transplantGetState(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
 int transplantPushState(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
-int transplantSinglestep(const FPGAContext *c, uint32_t thid, uint32_t asid, DevteroflexArchState *state);
+int transplantSinglestep(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
 int transplantPending(const FPGAContext *c, uint32_t *pending_threads);
 int transplantFreePending(const FPGAContext *c, uint32_t pending_threads);
 int transplantWaitTillPending(const FPGAContext *c, uint32_t *pending_threads);

--- a/regression/src/client/fpga_interface.h
+++ b/regression/src/client/fpga_interface.h
@@ -114,24 +114,9 @@ typedef struct MessageFPGA
  *
  * XREGS: uint64_t
  * PC   : uint64_t
- * SP   : uint64_t
- * CF/VF/NF/ZF : uint64_t
+ * Flags : uint64_t
+ * icount : uint64_t
  */
-#define ARCH_PSTATE_PC_OFFST     (32)
-#define ARCH_PSTATE_SP_OFFST     (33)
-#define ARCH_PSTATE_FLAGS_OFFST  (34)
-#define ARCH_PSTATE_ICOUNT_OFFST (35)
-#define ARCH_PSTATE_TOT_REGS     (36)
-#define ARCH_PSTATE_NF_MASK      (3)    // 64bit 3
-#define ARCH_PSTATE_ZF_MASK      (2)    // 64bit 2
-#define ARCH_PSTATE_CF_MASK      (1)    // 64bit 1
-#define ARCH_PSTATE_VF_MASK      (0)    // 64bit 0
-
-#define FLAGS_GET_NZCV(flags)               (flags & 0xF)
-#define FLAGS_GET_IS_EXCEPTION(flags)       (flags & (1 << 4))
-#define FLAGS_GET_IS_UNDEF(flags)           (flags & (1 << 5))
-#define FLAGS_GET_IS_ICOUNT_DEPLETED(flags) (flags & (1 << 6))
-
 typedef struct DevteroflexArchState {
 	uint64_t xregs[32];
 	uint64_t pc;
@@ -146,6 +131,21 @@ typedef struct DevteroflexArchState {
     uint64_t _unused_[5];
 } DevteroflexArchState;
 
+#define ARCH_PSTATE_XREG_OFFST   (0)
+#define ARCH_PSTATE_PC_OFFST     (32)
+#define ARCH_PSTATE_FLAGS_OFFST  (33)
+#define ARCH_PSTATE_ICOUNT_OFFST (34)
+#define ARCH_PSTATE_TOT_REGS     (35)
+
+#define FLAGS_GET_NZCV(flags)               (flags & 0xF)
+#define FLAGS_GET_IS_EXCEPTION(flags)       (flags & (1 << 4))
+#define FLAGS_GET_IS_UNDEF(flags)           (flags & (1 << 5))
+#define FLAGS_GET_IS_ICOUNT_DEPLETED(flags) (flags & (1 << 6))
+
+#define ARCH_PSTATE_NF_MASK      (3)    // 64bit 3
+#define ARCH_PSTATE_ZF_MASK      (2)    // 64bit 2
+#define ARCH_PSTATE_CF_MASK      (1)    // 64bit 1
+#define ARCH_PSTATE_VF_MASK      (0)    // 64bit 0
 
 // MMU
 int  mmuRegisterTHID2ASID(const struct FPGAContext *c, uint32_t thid, uint32_t asid);
@@ -176,6 +176,9 @@ int dramPagePull(const FPGAContext *c, uint64_t paddr, void *page);
 #define TRANS_REG_OFFST_START            (0x4 * 1)
 #define TRANS_REG_OFFST_STOP_CPU         (0x4 * 2)
 #define TRANS_REG_OFFST_FORCE_TRANSPLANT (0x4 * 3)
+#define TRANS_STATE_SIZE_BYTES      (320)   // 5 512-bit blocks; State fits in this amount of bytes
+#define TRANS_STATE_THID_MAX_BYTES  (512)   // 8 512-bit blocks; max bytes allocated per thread
+#define TRANS_STATE_THID_MAX_REGS   (512/8) // 64 64-bit words: total regs allocated per thread
 int transplantRegisterAndPush(const FPGAContext *c, uint32_t thid, uint32_t asid, DevteroflexArchState *state);
 int transplantUnregisterAndPull(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
 int transplantGetState(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);

--- a/regression/src/client/fpga_interface.h
+++ b/regression/src/client/fpga_interface.h
@@ -201,7 +201,6 @@ int transplantPushAndWait(const FPGAContext *c, uint32_t thid, DevteroflexArchSt
 int transplantPushAndStart(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
 int transplantPushAndSinglestep(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
 int transplantGetState(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
-int transplantPushState(const FPGAContext *c, uint32_t thid, DevteroflexArchState *state);
 int transplantPending(const FPGAContext *c, uint32_t *pending_threads);
 int transplantFreePending(const FPGAContext *c, uint32_t pending_threads);
 int transplantWaitTillPending(const FPGAContext *c, uint32_t *pending_threads);

--- a/regression/src/client/fpga_interface.h
+++ b/regression/src/client/fpga_interface.h
@@ -128,14 +128,22 @@ typedef struct DevteroflexArchState {
             uint32_t icountBudget;
         };
     };
-    uint64_t _unused_[5];
+    union {
+        uint64_t asid_reg;
+        struct {
+            uint32_t asid;
+            uint32_t _asid_unused_;
+        }
+    }
+    uint64_t _unused_[4];
 } DevteroflexArchState;
 
 #define ARCH_PSTATE_XREG_OFFST   (0)
 #define ARCH_PSTATE_PC_OFFST     (32)
 #define ARCH_PSTATE_FLAGS_OFFST  (33)
 #define ARCH_PSTATE_ICOUNT_OFFST (34)
-#define ARCH_PSTATE_TOT_REGS     (35)
+#define ARCH_PSTATE_ASID_OFFST   (35)
+#define ARCH_PSTATE_TOT_REGS     (36)
 
 #define FLAGS_GET_NZCV(flags)               (flags & 0xF)
 #define FLAGS_GET_IS_EXCEPTION(flags)       (flags & (1 << 4))

--- a/regression/src/client/main.cpp
+++ b/regression/src/client/main.cpp
@@ -122,7 +122,7 @@ TEST_CASE("basic-transplant-with-initial-page-fault"){
   uint32_t asid = GET_asid(th);
 
   // initialization.
-  transplantRegisterAndPush(&c, th, asid, &state);
+  transplantPushAndWait(&c, th, asid, &state);
   mmuRegisterTHID2ASID(&c, th, asid);
   transplantStart(&c, th);
 
@@ -196,7 +196,7 @@ TEST_CASE("execute-instruction-with-context-in-dram"){
 
   // prepare for transplant.
   INFO("Transplant state to FPGA");
-  REQUIRE(transplantRegisterAndPush(&c, thid, asid, &state) == 0);
+  REQUIRE(transplantPushAndWait(&c, thid, asid, &state) == 0);
 
   // start execution
   INFO("Start execution");
@@ -282,7 +282,7 @@ TEST_CASE("execute-instruction") {
   INFO("Transplant state to FPGA");
   uint32_t thid = 3;
   uint32_t asid = GET_asid(thid);
-  REQUIRE(transplantRegisterAndPush(&c, thid, asid, &state) == 0);
+  REQUIRE(transplantPushAndWait(&c, thid, asid, &state) == 0);
 
   // start execution
   INFO("Start execution");

--- a/regression/src/client/main.cpp
+++ b/regression/src/client/main.cpp
@@ -120,10 +120,10 @@ TEST_CASE("basic-transplant-with-initial-page-fault"){
 
   int th = 3;
   uint32_t asid = GET_asid(th);
+  state.asid = asid;
 
   // initialization.
-  transplantPushAndWait(&c, th, asid, &state);
-  mmuRegisterTHID2ASID(&c, th, asid);
+  transplantPushAndWait(&c, th, &state);
   transplantStart(&c, th);
 
   // Let's query message. It should be a page fault.
@@ -196,7 +196,8 @@ TEST_CASE("execute-instruction-with-context-in-dram"){
 
   // prepare for transplant.
   INFO("Transplant state to FPGA");
-  REQUIRE(transplantPushAndWait(&c, thid, asid, &state) == 0);
+  state.asid = asid;
+  REQUIRE(transplantPushAndWait(&c, thid, &state) == 0);
 
   // start execution
   INFO("Start execution");
@@ -215,7 +216,7 @@ TEST_CASE("execute-instruction-with-context-in-dram"){
 
   // make it back
   INFO("Transplant thread back");
-  transplantUnregisterAndPull(&c, thid, &state);
+  transplantGetState(&c, thid, &state);
 
   // check context
   INFO("Check context");
@@ -282,7 +283,8 @@ TEST_CASE("execute-instruction") {
   INFO("Transplant state to FPGA");
   uint32_t thid = 3;
   uint32_t asid = GET_asid(thid);
-  REQUIRE(transplantPushAndWait(&c, thid, asid, &state) == 0);
+  state.asid = asid;
+  REQUIRE(transplantPushAndWait(&c, thid, &state) == 0);
 
   // start execution
   INFO("Start execution");
@@ -344,14 +346,16 @@ TEST_CASE("execute-instruction") {
 
   // make it back
   INFO("Transplant thread back");
-  transplantUnregisterAndPull(&c, thid, &state);
+  transplantGetState(&c, thid, &state);
 
   // check context
-  INFO("Check context");
+  INFO("Check context regs");
   REQUIRE(state.xregs[0] == 10);
   REQUIRE(state.xregs[1] == 0);
+  INFO("Check context PC");
   REQUIRE(state.pc == pc + 4 * 6);
 
+  INFO("Get back page");
   uint8_t data_buffer[4096];
   synchronizePage(&c, asid, data_buffer, 0, page_data_paddr, true);
   // CHECK its value

--- a/regression/src/client/runs/stress-tests.c
+++ b/regression/src/client/runs/stress-tests.c
@@ -30,7 +30,8 @@ int main(int argc, char **argv) {
     for(int thread = 0; thread < threads; thread++) {
         initArchState(&state, thread << 12);
         initState_infinite_loop(&state, true);
-        transplantPushAndWait(&ctx, thread, thread, &state);
+        state.asid = thread;
+        transplantPushAndWait(&ctx, thread, &state);
         MessageFPGA pf_reply;
         makeMissReply(INST_FETCH, -1, thread, state.pc, paddr, &pf_reply);
         mmuMsgSend(&ctx, &pf_reply);

--- a/regression/src/client/runs/stress-tests.c
+++ b/regression/src/client/runs/stress-tests.c
@@ -30,7 +30,7 @@ int main(int argc, char **argv) {
     for(int thread = 0; thread < threads; thread++) {
         initArchState(&state, thread << 12);
         initState_infinite_loop(&state, true);
-        transplantRegisterAndPush(&ctx, thread, thread, &state);
+        transplantPushAndWait(&ctx, thread, thread, &state);
         MessageFPGA pf_reply;
         makeMissReply(INST_FETCH, -1, thread, state.pc, paddr, &pf_reply);
         mmuMsgSend(&ctx, &pf_reply);

--- a/regression/src/client/tests/back-pressure.cc
+++ b/regression/src/client/tests/back-pressure.cc
@@ -74,7 +74,7 @@ static int test_stress_memory(
       curr_ld_page_vaddr[thid], 
       curr_st_page_vaddr[thid]);
     state[thid].pc = safeCheckTransplants ? pc : pc+4;
-    transplantRegisterAndPush(ctx, thid, asid[thid], &state[thid]);
+    transplantPushAndWait(ctx, thid, asid[thid], &state[thid]);
   }
 
   INFO("- Push Instruction Pages to each thread");
@@ -116,7 +116,7 @@ static int test_stress_memory(
 
   INFO("- Start programs");
   for(uint32_t thid = 0; thid < thidN; thid++) {
-   transplantRegisterAndPush(ctx, thid, asid[thid], &state[thid]);
+   transplantPushAndWait(ctx, thid, asid[thid], &state[thid]);
    REQUIRE(transplantStart(ctx, thid) == 0);
   }
 

--- a/regression/src/client/tests/host-control.cc
+++ b/regression/src/client/tests/host-control.cc
@@ -30,13 +30,8 @@ TEST_CASE("host-cmd-stop-cpu") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantPushAndWait(&ctx, 0, asid, &state);
-
-    INFO("Advance");
-    advanceTicks(&ctx, 100);
-
-    INFO("Start Execution");
-    transplantStart(&ctx, 0);
+    state.asid = asid;
+    transplantPushAndStart(&ctx, 0, &state);
 
     INFO("Advance");
     advanceTicks(&ctx, 100);
@@ -77,7 +72,8 @@ TEST_CASE("host-cmd-force-transplant") {
     fclose(f);
 
     INFO("Push state");
-    transplantPushAndWait(&ctx, 0, asid, &state);
+    state.asid = asid;
+    transplantPushAndStart(&ctx, 0, &state);
 
     INFO("Advance");
     advanceTicks(&ctx, 100);
@@ -101,7 +97,7 @@ TEST_CASE("host-cmd-force-transplant") {
     assert(pending_threads);
 
     INFO("Check flag")
-    transplantUnregisterAndPull(&ctx, 0, &state);
+    transplantGetState(&ctx, 0, &state);
     assert(FLAGS_GET_IS_EXCEPTION(state.flags));
  
     releaseFPGAContext(&ctx);
@@ -114,6 +110,7 @@ TEST_CASE("host-cmd-singlestep") {
     REQUIRE(initFPGAContext(&ctx) == 0);
     initArchState(&state, 0xABCDABCD0000);
     initState_simple_inst(&state, 0x10, 0x33);
+    state.asid = asid;
     int paddr = ctx.ppage_base_addr;
 
     INFO("Get binary")
@@ -129,45 +126,33 @@ TEST_CASE("host-cmd-singlestep") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantPushAndWait(&ctx, 0, asid, &state);
+    transplantPushAndSinglestep(&ctx, 0, &state);
     INFO("Push state");
-    transplantPushAndWait(&ctx, 1, asid, &state);
-
-    INFO("Setup stop CPU");
-    transplantStopCPU(&ctx, 0);
-    transplantStopCPU(&ctx, 1);
-
-    INFO("Advance");
-    advanceTicks(&ctx, 100);
-
-    INFO("Check transplants");
-    uint32_t pending_threads;
-    transplantPending(&ctx, &pending_threads);
-    assert(!pending_threads);
-
-    INFO("Start Execution");
-    transplantStart(&ctx, 0); 
-    transplantStart(&ctx, 1); 
+    transplantPushAndSinglestep(&ctx, 1, &state);
 
     INFO("Advance");
     advanceTicks(&ctx, 1000);
 
     INFO("Check now execution stopped");
+    uint32_t pending_threads;
     transplantPending(&ctx, &pending_threads);
     assert(pending_threads & 0b11);
 
     INFO("Check state 0");
-    transplantUnregisterAndPull(&ctx, 0, &state);
+    transplantGetState(&ctx, 0, &state);
     assert(state.xregs[2] = state.xregs[0] + state.xregs[1]);
     assert(state.xregs[2] = state.xregs[0] + state.xregs[1]);
     INFO("Check icount 0");
     assert(state.icount == 1);
     INFO("Check state 1");
-    transplantUnregisterAndPull(&ctx, 1, &state);
+    transplantGetState(&ctx, 1, &state);
     assert(state.xregs[2] = state.xregs[0] + state.xregs[1]);
     assert(state.xregs[2] = state.xregs[0] + state.xregs[1]);
     INFO("Check icount 1");
     assert(state.icount == 1);
+
+    transplantPending(&ctx, &pending_threads);
+    assert(pending_threads == 0);
  
     releaseFPGAContext(&ctx);
 }
@@ -194,7 +179,8 @@ TEST_CASE("check-flag-undef") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantPushAndWait(&ctx, 0, asid, &state);
+    state.asid = asid;
+    transplantPushAndWait(&ctx, 0, &state);
 
     INFO("Start Execution");
     transplantStart(&ctx, 0); 
@@ -208,7 +194,7 @@ TEST_CASE("check-flag-undef") {
     assert(pending_threads);
 
     INFO("Check transplant");
-    transplantUnregisterAndPull(&ctx, 0, &state);
+    transplantGetState(&ctx, 0, &state);
     printf("flags: %lx\n", state.flags);
     assert(FLAGS_GET_IS_UNDEF(state.flags));
     INFO("Check icount");
@@ -239,7 +225,8 @@ TEST_CASE("check-flag-transplant") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantPushAndWait(&ctx, 0, asid, &state);
+    state.asid = asid;
+    transplantPushAndWait(&ctx, 0, &state);
 
     INFO("Start Execution");
     transplantStart(&ctx, 0); 
@@ -253,7 +240,7 @@ TEST_CASE("check-flag-transplant") {
     assert(pending_threads);
 
     INFO("Check transplant");
-    transplantUnregisterAndPull(&ctx, 0, &state);
+    transplantGetState(&ctx, 0, &state);
     printf("flags: %lx\n", state.flags);
     assert(FLAGS_GET_IS_EXCEPTION(state.flags));
     INFO("Check icount");
@@ -284,7 +271,8 @@ TEST_CASE("check-icount-budget") {
 
     INFO("Push state");
     state.icountBudget = 100;
-    transplantPushAndWait(&ctx, 0, asid, &state);
+    state.asid = asid;
+    transplantPushAndWait(&ctx, 0, &state);
 
     INFO("Advance");
     advanceTicks(&ctx, 100);
@@ -308,7 +296,7 @@ TEST_CASE("check-icount-budget") {
     assert(pending_threads);
 
     INFO("Check transplant");
-    transplantUnregisterAndPull(&ctx, 0, &state);
+    transplantGetState(&ctx, 0, &state);
     printf("flags: %lx\n", state.flags);
 
     INFO("Check icount depletion");

--- a/regression/src/client/tests/host-control.cc
+++ b/regression/src/client/tests/host-control.cc
@@ -30,7 +30,7 @@ TEST_CASE("host-cmd-stop-cpu") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantRegisterAndPush(&ctx, 0, asid, &state);
+    transplantPushAndWait(&ctx, 0, asid, &state);
 
     INFO("Advance");
     advanceTicks(&ctx, 100);
@@ -77,7 +77,7 @@ TEST_CASE("host-cmd-force-transplant") {
     fclose(f);
 
     INFO("Push state");
-    transplantRegisterAndPush(&ctx, 0, asid, &state);
+    transplantPushAndWait(&ctx, 0, asid, &state);
 
     INFO("Advance");
     advanceTicks(&ctx, 100);
@@ -129,9 +129,9 @@ TEST_CASE("host-cmd-singlestep") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantRegisterAndPush(&ctx, 0, asid, &state);
+    transplantPushAndWait(&ctx, 0, asid, &state);
     INFO("Push state");
-    transplantRegisterAndPush(&ctx, 1, asid, &state);
+    transplantPushAndWait(&ctx, 1, asid, &state);
 
     INFO("Setup stop CPU");
     transplantStopCPU(&ctx, 0);
@@ -194,7 +194,7 @@ TEST_CASE("check-flag-undef") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantRegisterAndPush(&ctx, 0, asid, &state);
+    transplantPushAndWait(&ctx, 0, asid, &state);
 
     INFO("Start Execution");
     transplantStart(&ctx, 0); 
@@ -239,7 +239,7 @@ TEST_CASE("check-flag-transplant") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantRegisterAndPush(&ctx, 0, asid, &state);
+    transplantPushAndWait(&ctx, 0, asid, &state);
 
     INFO("Start Execution");
     transplantStart(&ctx, 0); 
@@ -284,7 +284,7 @@ TEST_CASE("check-icount-budget") {
 
     INFO("Push state");
     state.icountBudget = 100;
-    transplantRegisterAndPush(&ctx, 0, asid, &state);
+    transplantPushAndWait(&ctx, 0, asid, &state);
 
     INFO("Advance");
     advanceTicks(&ctx, 100);

--- a/regression/src/client/tests/load-store.cc
+++ b/regression/src/client/tests/load-store.cc
@@ -55,7 +55,7 @@ static void step_ldst_all_sizes_pair_load(FPGAContext *ctx,
                                           uint64_t exp1, uint64_t exp2) {
   uint32_t pending_threads;
   INFO("Push thread and start");
-  transplantRegisterAndPush(ctx, thid, asid, state);
+  transplantPushAndWait(ctx, thid, asid, state);
   REQUIRE(transplantStart(ctx, thid) == 0);
   INFO("Wait for transplant and fetch")
   transplantWaitTillPending(ctx, &pending_threads);
@@ -204,7 +204,7 @@ TEST_CASE("out-of-page-bound-pair-load") {
   fclose(f);
 
   INFO("- Start execution");
-  REQUIRE(transplantRegisterAndPush(&ctx, thid, asid, &state) == 0);
+  REQUIRE(transplantPushAndWait(&ctx, thid, asid, &state) == 0);
   REQUIRE(transplantStart(&ctx, thid) == 0);
 
   // FPGA requires instruction page.
@@ -307,7 +307,7 @@ TEST_CASE("ldr-wback-addr") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantRegisterAndPush(&ctx, 0, asid, &state);
+    transplantPushAndWait(&ctx, 0, asid, &state);
 
     INFO("Start Execution");
     transplantStart(&ctx, 0); 

--- a/regression/src/client/tests/load-store.cc
+++ b/regression/src/client/tests/load-store.cc
@@ -55,12 +55,13 @@ static void step_ldst_all_sizes_pair_load(FPGAContext *ctx,
                                           uint64_t exp1, uint64_t exp2) {
   uint32_t pending_threads;
   INFO("Push thread and start");
-  transplantPushAndWait(ctx, thid, asid, state);
+  state->asid = asid;
+  transplantPushAndWait(ctx, thid, state);
   REQUIRE(transplantStart(ctx, thid) == 0);
   INFO("Wait for transplant and fetch")
   transplantWaitTillPending(ctx, &pending_threads);
   REQUIRE(pending_threads & (1 << thid));
-  transplantUnregisterAndPull(ctx, thid, state);
+  transplantGetState(ctx, thid, state);
   check_ldst_all_sizes_pair_load(state, exp1, exp2);
   state->pc += 4; // Get next instruction
 }
@@ -118,9 +119,6 @@ static int test_ldst_all_sizes_pair(FPGAContext *ctx) {
   dramPagePush(ctx, page_data_st_paddr, page);
   makeMissReply(DATA_STORE, -1, asid, vaddr_st, page_data_st_paddr, &pf_reply);
   mmuMsgSend(ctx, &pf_reply);
-
-  INFO("- Register thread")
-  mmuRegisterTHID2ASID(ctx, thid, asid);
 
   // INFO("Verify load pair byte");
   // step_ldst_all_sizes_loads(ctx, &state, 0xAB, 0xBA);
@@ -204,7 +202,8 @@ TEST_CASE("out-of-page-bound-pair-load") {
   fclose(f);
 
   INFO("- Start execution");
-  REQUIRE(transplantPushAndWait(&ctx, thid, asid, &state) == 0);
+  state.asid = asid;
+  REQUIRE(transplantPushAndWait(&ctx, thid, &state) == 0);
   REQUIRE(transplantStart(&ctx, thid) == 0);
 
   // FPGA requires instruction page.
@@ -258,7 +257,7 @@ TEST_CASE("out-of-page-bound-pair-load") {
     usleep(1e5);
   }
   REQUIRE((pending_threads & (1 << thid)) != 0);
-  transplantUnregisterAndPull(&ctx, thid, &state);
+  transplantGetState(&ctx, thid, &state);
 
   synchronizePage(&ctx, asid, (uint8_t *)data_pages[1], expected_vas[1], pas[1], true);
   synchronizePage(&ctx, asid, (uint8_t *)data_pages[2], expected_vas[2], pas[2], true);
@@ -307,7 +306,8 @@ TEST_CASE("ldr-wback-addr") {
     mmuMsgSend(&ctx, &pf_reply);
 
     INFO("Push state");
-    transplantPushAndWait(&ctx, 0, asid, &state);
+    state.asid = asid;
+    transplantPushAndWait(&ctx, 0, &state);
 
     INFO("Start Execution");
     transplantStart(&ctx, 0); 
@@ -321,7 +321,7 @@ TEST_CASE("ldr-wback-addr") {
     assert(pending_threads);
 
     INFO("Check transplant");
-    transplantUnregisterAndPull(&ctx, 0, &state);
+    transplantGetState(&ctx, 0, &state);
     INFO("Check address");
     assert(state.xregs[0] == addr);
     INFO("Check data");

--- a/regression/src/client/tests/memory-ordering.cc
+++ b/regression/src/client/tests/memory-ordering.cc
@@ -15,15 +15,14 @@ TEST_CASE("transplant-data-and-request-order") {
   initArchState(&differentState, 0x4000);
   MessageFPGA msg;
 
-  mmuRegisterTHID2ASID(&c, 7, 0x10);
-  transplantPushState(&c, 0, &state);
-  transplantPushState(&c, 1, &state);
-  transplantPushState(&c, 2, &state);
-  transplantPushState(&c, 3, &state);
-  transplantPushState(&c, 4, &state);
-  transplantPushState(&c, 5, &state);
-  transplantPushState(&c, 6, &state);
-  transplantPushState(&c, 7, &differentState);
+  transplantPushAndWait(&c, 0, &state);
+  transplantPushAndWait(&c, 1, &state);
+  transplantPushAndWait(&c, 2, &state);
+  transplantPushAndWait(&c, 3, &state);
+  transplantPushAndWait(&c, 4, &state);
+  transplantPushAndWait(&c, 5, &state);
+  transplantPushAndWait(&c, 6, &state);
+  transplantPushAndWait(&c, 7, &differentState);
   transplantStart(&c, 7);
 
   mmuMsgGet(&c, &msg);

--- a/regression/src/client/tests/trace-module.cc
+++ b/regression/src/client/tests/trace-module.cc
@@ -27,7 +27,8 @@ TEST_CASE("trace-pcs-then-stop-single") {
     MessageFPGA pf_reply;
     makeMissReply(INST_FETCH, -1, thread, state.pc, paddr, &pf_reply);
     mmuMsgSend(&ctx, &pf_reply);
-    transplantPushAndWait(&ctx, thread, thread, &state);
+    state.asid = thread;
+    transplantPushAndWait(&ctx, thread, &state);
 
     INFO("Advance");
     advanceTicks(&ctx, 100);

--- a/regression/src/client/tests/trace-module.cc
+++ b/regression/src/client/tests/trace-module.cc
@@ -27,7 +27,7 @@ TEST_CASE("trace-pcs-then-stop-single") {
     MessageFPGA pf_reply;
     makeMissReply(INST_FETCH, -1, thread, state.pc, paddr, &pf_reply);
     mmuMsgSend(&ctx, &pf_reply);
-    transplantRegisterAndPush(&ctx, thread, thread, &state);
+    transplantPushAndWait(&ctx, thread, thread, &state);
 
     INFO("Advance");
     advanceTicks(&ctx, 100);

--- a/regression/src/client/tests/transplants.cc
+++ b/regression/src/client/tests/transplants.cc
@@ -14,7 +14,7 @@ TEST_CASE("transplant-in") {
   int ret = 0;
   const int th = 0;
 
-  REQUIRE(transplantPushState(&c, th, &state) == 0);
+  REQUIRE(transplantPushAndWait(&c, th, &state) == 0);
 
   // ---- Assert that correct state is was pushed
   DevteroflexArchState stateTransplant;

--- a/regression/src/client/tests/transplants.cc
+++ b/regression/src/client/tests/transplants.cc
@@ -47,7 +47,8 @@ TEST_CASE("transplant-transplants") {
 
   // ---- Push thread state
   INFO("Push state and register asid")
-  transplantPushAndWait(&c, th, asid, &state);
+  state.asid = asid;
+  transplantPushAndWait(&c, th, &state);
 
   // ---- Assert that correct state is was pushed
   INFO("Assert state is identical after pushing")
@@ -77,7 +78,7 @@ TEST_CASE("transplant-transplants") {
   // ---- Assert that state was not modified
   // ---- Now assert no instruction was executed
   INFO("Bring back state")
-  transplantUnregisterAndPull(&c, th, &stateTransplant);
+  transplantGetState(&c, th, &stateTransplant);
   INFO("Assert state hasn't changed")
   requireStateIsIdentical(state, stateTransplant);
  

--- a/regression/src/client/tests/transplants.cc
+++ b/regression/src/client/tests/transplants.cc
@@ -47,7 +47,7 @@ TEST_CASE("transplant-transplants") {
 
   // ---- Push thread state
   INFO("Push state and register asid")
-  transplantRegisterAndPush(&c, th, asid, &state);
+  transplantPushAndWait(&c, th, asid, &state);
 
   // ---- Assert that correct state is was pushed
   INFO("Assert state is identical after pushing")


### PR DESCRIPTION
Transplants can start directly after the AXI transaction completes.
One can also set a flag such as it waits for the host to start after the transplant has completed.