### PR TITLE
Platform Information on Hardware

### DIFF
--- a/Devteroflex/src/armflex/PipelineWithTransplant.scala
+++ b/Devteroflex/src/armflex/PipelineWithTransplant.scala
@@ -42,12 +42,6 @@ class PipelineParams(
 import antmicro.Bus.AXI4Lite
 
 class PipelineWithCSR(params: PipelineParams) extends Module {
-  // TODO: Not used anyways as we rely on another mechanism, we could remove this
-  private val uCSRVecAsid = Module(new StatusVecCSR(params.thidN, params.axiDataW))
-  val S_CSR_ThreadTable = IO(Flipped(uCSRVecAsid.io.bus.cloneType))
-  S_CSR_ThreadTable <> uCSRVecAsid.io.bus
-  uCSRVecAsid.io.vec := 0.U.asTypeOf(uCSRVecAsid.io.vec.cloneType)
-
   val pipelineU = Module(new PipelineWithTransplant(params))
   val S_CSR_Pipeline = IO(Flipped(pipelineU.hostIO.S_CSR.cloneType))
   S_CSR_Pipeline <> pipelineU.hostIO.S_CSR

--- a/regression/src/client/fpga.h
+++ b/regression/src/client/fpga.h
@@ -5,11 +5,12 @@
 
 // Base addresses
 // BAR1 - AXIL
-#define BASE_ADDR_AXIL             (0x000000000000)
-
-// PCIS - AXI
-#define BASE_ADDR_DRAM             (0x000000000000)
-#define BASE_ADDR_RTL              (0x001000000000)
+#define BASE_ADDR_AXIL                   (0x000000000000)
+#define BASE_ADDR_PLATFORM_INFO          (BASE_ADDR_AXIL + 0x0)
+#define VERILOG_GENERATED_TIME_LO        (0x4 * 0)
+#define VERILOG_GENERATED_TIME_HI        (0x4 * 1)
+#define PLATFORM_PADDR_WIDTH             (0x4 * 2)
+#define PLATFORM_THREAD_NUMBER           (0x4 * 3)
 
 typedef struct FPGAContext {
 #ifndef AWS_FPGA
@@ -22,6 +23,9 @@ typedef struct FPGAContext {
 #endif
   uint64_t dram_size;
   uint64_t ppage_base_addr;
+
+  uint64_t dram_addr_base;
+  uint64_t axi_peri_addr_base; 
 } FPGAContext;
 
 

--- a/regression/src/client/fpga_interface.c
+++ b/regression/src/client/fpga_interface.c
@@ -168,7 +168,7 @@ int dramPagePush(const FPGAContext *c, uint64_t paddr, void *page){
     paddr ^= (paddr & 0xFFFUL);
   }
   assert(paddr < c->dram_size && "DRAM range overflow.");
-  return writeAXI(c, BASE_ADDR_DRAM + paddr, page, PAGE_SIZE);
+  return writeAXI(c, c->dram_addr_base + paddr, page, PAGE_SIZE);
 }
 
 /**
@@ -235,7 +235,7 @@ int dramPagePull(const FPGAContext *c, uint64_t paddr, void *page){
     paddr ^= (paddr & 0xFFFUL);
   }
   assert(paddr < c->dram_size && "DRAM range overflow.");
-  return readAXI(c, BASE_ADDR_DRAM + paddr, page, PAGE_SIZE);
+  return readAXI(c, c->dram_addr_base + paddr, page, PAGE_SIZE);
 }
 
 uint32_t assertFailedGet(const FPGAContext *c, int reg) {

--- a/regression/src/client/fpga_interface.h
+++ b/regression/src/client/fpga_interface.h
@@ -182,7 +182,7 @@ int dramPagePull(const FPGAContext *c, uint64_t paddr, void *page);
 #define MMU_MSG_QUEUE_REG_OFST_PUSH      (0x8)
 #define MMU_MSG_QUEUE_REG_OFST_POP       (0xC)
 
-#define BASE_ADDR_AXI_MMU_MSG            (BASE_ADDR_RTL + 0x10000)
+#define BASE_ADDR_AXI_MMU_MSG            (c->axi_peri_addr_base + 0x10000)
 bool mmuMsgHasPending(const FPGAContext *c);
 int  mmuMsgGet(const FPGAContext *c, MessageFPGA *msg);
 int  mmuMsgPeek(const FPGAContext *c, MessageFPGA *msg);
@@ -204,11 +204,9 @@ uint64_t pmuTotalCycles(const FPGAContext *c);
 uint64_t pmuTotalCommitInstructions(const FPGAContext *c);
 int pmuReadCycleCounters(const FPGAContext *c, int index, uint16_t counters[16]);
 
-
-
 // State transplants
-#define BASE_ADDR_TRANSPLANT_DATA        (BASE_ADDR_RTL + 0x0)
-#define BASE_ADDR_BIND_ASID_THID         (BASE_ADDR_AXIL + 0x0)
+#define BASE_ADDR_TRANSPLANT_DATA        (c->axi_peri_addr_base + 0x0)
+// #define BASE_ADDR_BIND_ASID_THID         (BASE_ADDR_AXIL + 0x0)
 #define BASE_ADDR_TRANSPLANT_CTRL        (BASE_ADDR_AXIL + 0x100 * 0x4)
 #define TRANS_REG_OFFST_PENDING          (0x4 * 0)
 #define TRANS_REG_OFFST_FREE_PENDING     (0x4 * 0)

--- a/regression/src/server/dut.hh
+++ b/regression/src/server/dut.hh
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "Vdevteroflex_top.h"
-#include "../client/fpga_interface.h"
 #include <exception>
 #include <mutex>
 #include <thread>

--- a/regression/src/server/subroutine.cc
+++ b/regression/src/server/subroutine.cc
@@ -302,7 +302,7 @@ void AXIRoutine(TopDUT &dut, IPCServer &ipc) {
     } else if (result.is_write) {
       // it's a writing request, activate AXI writing request channel.
       // printf("SHELL:HOST:AXI FPGA:WR[0x%lx]:BURST[%lu]\n", result.addr, result.byte_size);
-      dut->S_AXI_awaddr = result.addr;
+      dut->S_AXI_awaddr = result.addr - dut.dram_size;
       dut->S_AXI_awsize = 6;
       dut->S_AXI_awburst = 1;
       dut->S_AXI_awlen = (result.byte_size / BYTES_PER_BLOCK) - 1;
@@ -358,7 +358,7 @@ void AXIRoutine(TopDUT &dut, IPCServer &ipc) {
     } else {
       // printf("SHELL:HOST:AXI FPGA:RD[0x%lx]:BURST[%lu]\n", result.addr, result.byte_size);
       // read operation
-      dut->S_AXI_araddr = result.addr;
+      dut->S_AXI_araddr = result.addr - dut.dram_size;;
       dut->S_AXI_arlen = (result.byte_size / BYTES_PER_BLOCK) - 1;
       dut->S_AXI_arburst = 1;
       dut->S_AXI_arsize = 6;


### PR DESCRIPTION
This PR adds registers software can access to know the platform information. At present, the following information is supported:
- Verilog Generation Time
- Physical address size
- Number of maximum hardware threads

At present, the software simulator will use the PA size to allocate DRAM, and the FPGA runtime will use the PA size to determine the DRAM size, and determine the base address of the AXI RTL peripherals. With this feature, there is no need to have special configs for simulator and real FPGA. 